### PR TITLE
ci: update the version of golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,13 +12,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: stable
+          go-version-file: 'go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 #v8.0.0
         with:
-          version: v2.4.0
+          version: v2.10

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/gemaraproj/go-gemara
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.24.5
+toolchain go1.24.13
 
 require (
 	github.com/defenseunicorns/go-oscal v0.7.0


### PR DESCRIPTION
This PR updates the go version in `go.mod` and golangci-lint to fix CI failures