### PR TITLE
fix: adjusted catalog md title to match baseline's current generator

### DIFF
--- a/gemaraconv/markdown/templates/catalog.tmpl
+++ b/gemaraconv/markdown/templates/catalog.tmpl
@@ -1,4 +1,6 @@
-{{ define "catalog"}}# {{.Title}} - {{.Metadata.Id}} {{.Metadata.Version}}
+{{ define "catalog"}}# {{.Title}}
+
+Version: {{.Metadata.Version}}
 
 {{if .ShowMetadata}}{{ template "metadata" .}}{{end}}
 

--- a/gemaraconv/markdown_test.go
+++ b/gemaraconv/markdown_test.go
@@ -63,7 +63,7 @@ func TestCatalogToMarkdown_goodCCCYAML(t *testing.T) {
 		numARs += len(c.AssessmentRequirements)
 	}
 
-	assert.Contains(t, s, fmt.Sprintf("# %s - %s", catalog.Title, catalog.Metadata.Id))
+	assert.Contains(t, s, fmt.Sprintf("# %s\n\nVersion: %s", catalog.Title, catalog.Metadata.Version))
 	assert.Contains(t, s, "_"+catalog.Title+"_ is a Gemara")
 	assert.Contains(t, s, "## Table of contents")
 	assert.Contains(t, s, fmt.Sprintf("- [%s](#%s)", group0.Title, markdown.Anchor(group0.Id)))


### PR DESCRIPTION
I was trying different title formats while working on the #41 and it occurred to me now that we shouldn't adjust what Baseline is already doing for the title