### PR TITLE
feat: add security-insights.yml for OSPS baseline scanning

### DIFF
--- a/security-insights.yml
+++ b/security-insights.yml
@@ -15,7 +15,6 @@ repository:
     - name: Eddie Knight
       affiliation: Sonatype
       email: knight@linux.com
-      primary: false
     - name: Jenn Power
       affiliation: Red Hat
       email: barnabei.jennifer@gmail.com

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -1,0 +1,83 @@
+header:
+  schema-version: 2.0.0
+  last-updated: '2026-04-06'
+  last-reviewed: '2026-04-06'
+  url: https://github.com/gemaraproj/go-gemara
+  project-si-source: https://raw.githubusercontent.com/gemaraproj/.github/refs/heads/main/.github/security-insights.yml
+
+repository:
+  url: https://github.com/gemaraproj/go-gemara
+  status: active
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  core-team:
+    - name: Eddie Knight
+      affiliation: Sonatype
+      email: knight@linux.com
+      primary: false
+    - name: Jenn Power
+      affiliation: Red Hat
+      email: barnabei.jennifer@gmail.com
+      primary: true
+    - name: Jason Meridth
+      affiliation: GitHub
+      email: jmeridth@gmail.com
+      primary: false
+    - name: Travis Truman
+      affiliation: Independent
+      email: trumant@gmail.com
+      primary: false
+    - name: Alex Speasmaker
+      affiliation: USAA
+      email: alex.speasmaker@gmail.com
+      primary: false
+  documentation:
+    contributing-guide: https://github.com/gemaraproj/gemara/blob/main/CONTRIBUTING.md
+  license:
+    url: https://github.com/gemaraproj/go-gemara?tab=Apache-2.0-1-ov-file#readme
+    expression: Apache-2.0
+  security:
+    assessments:
+      self:
+        comment: |
+          Self assessment has not yet been completed.
+    tools:
+      - name: Dependabot
+        type: SCA
+        version: "2"
+        rulesets:
+          - built-in
+        results:
+          adhoc:
+            name: Scheduled SCA Scan Results
+            predicate-uri: https://docs.github.com/en/graphql/reference/objects#repositoryvulnerabilityalert
+            location: https://github.com/gemaraproj/go-gemara/security/dependabot
+            comment: |
+              The results of the scheduled SCA scan are available in the Dependabot tab of the Security Insights page.
+        integration:
+          adhoc: true
+          ci: false
+          release: false
+      - name: CodeQL
+        type: SAST
+        version: "2.y.z"
+        rulesets:
+          - go
+          - actions
+        results:
+          adhoc:
+            name: Scheduled SAST Results
+            predicate-uri: https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/schemas/sarif-schema-2.1.0.json
+            location: https://github.com/gemaraproj/go-gemara/security/code-scanning
+            comment: |
+              The results of the scheduled SAST scan are available in the Code Scanning tab of the Security Insights page and as an artifact on the scheduled job.
+          ci:
+            name: CI SAST Results
+            predicate-uri: https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/schemas/sarif-schema-2.1.0.json
+            location: https://github.com/gemaraproj/go-gemara/security/code-scanning
+            comment: |
+              The results of the CI SAST scan are available in the Code Scanning tab of the Security Insights page.
+        integration:
+          adhoc: true
+          ci: true
+          release: false

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -1,3 +1,4 @@
+---
 header:
   schema-version: 2.0.0
   last-updated: '2026-04-06'

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -70,3 +70,20 @@ repository:
           adhoc: true
           ci: true
           release: false
+      - name: Kusari Inspector
+        type: other
+        rulesets:
+          - default
+        comment: |
+          Kusari Inspector is set up to scan on pull request submissions.
+          It analyzes dependency changes, licenses, vulnerabilities, code security,
+          and workflow risks, posting results as PR comments via the GitHub App.
+        results:
+          ci:
+            name: CI Scan Results
+            predicate-uri: https://docs.kusari.cloud/Inspector/integrations/github
+            location: https://github.com/gemaraproj/go-gemara/pulls
+        integration:
+          adhoc: false
+          ci: true
+          release: false

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -41,7 +41,8 @@ repository:
             predicate-uri: https://docs.github.com/en/graphql/reference/objects#repositoryvulnerabilityalert
             location: https://github.com/gemaraproj/go-gemara/security/dependabot
             comment: |
-              The results of the scheduled SCA scan are available in the Dependabot tab of the Security Insights page.
+              Dependabot runs every Monday. 
+              The configuration can be found here: https://github.com/gemaraproj/go-gemara/blob/main/.github/dependabot.yaml
         integration:
           adhoc: true
           ci: false

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -19,18 +19,6 @@ repository:
       affiliation: Red Hat
       email: barnabei.jennifer@gmail.com
       primary: true
-    - name: Jason Meridth
-      affiliation: GitHub
-      email: jmeridth@gmail.com
-      primary: false
-    - name: Travis Truman
-      affiliation: Independent
-      email: trumant@gmail.com
-      primary: false
-    - name: Alex Speasmaker
-      affiliation: USAA
-      email: alex.speasmaker@gmail.com
-      primary: false
   documentation:
     contributing-guide: https://github.com/gemaraproj/gemara/blob/main/CONTRIBUTING.md
   license:


### PR DESCRIPTION
## Summary

- Adds `security-insights.yml` to the project root to enable OSPS Baseline scanning
- Mirrors the structure of the reference file in `gemaraproj/gemara`
- The `baseline-scanner.yml` workflow was already present in the repository

Closes #16

## Changes

- `security-insights.yml`: new file declaring schema version, repository metadata, core team, license, and security tooling (Dependabot SCA + CodeQL SAST) following the [Security Insights v2 spec](https://github.com/ossf/security-insights-spec)

## Test plan

- [ ] Verify OSPS Baseline Scanner workflow runs successfully after merge
- [ ] Confirm `security-insights.yml` is valid against the Security Insights v2 schema