### PR TITLE
feat: update catalog markdown generator

### DIFF
--- a/gemaraconv/markdown/templates/catalog.tmpl
+++ b/gemaraconv/markdown/templates/catalog.tmpl
@@ -63,9 +63,17 @@ This document builds upon all of the requirements and applicability groups detai
 {{end}}
 {{if .Imports}}## Imports
 
-{{template "multi_entry_mapping_table_start"}}
-{{range .Imports}}{{template "multi_entry_mapping_table_row" .}}{{end}}
+The following controls are imported from external catalogs. All assessment requirements and other relevant details for these controls can be found in the respective catalog's source.
 
+{{range .Imports}}### {{lexiconLink .ReferenceId}}{{if .Title}}: {{.Title}}{{end}}
+
+{{if .Remarks}}{{.Remarks}}
+
+{{end}}{{if .Url}}**Source:** [{{.Url}}]({{.Url}})
+
+{{end}}{{range .Entries}}#### {{.ReferenceId}}{{if .Remarks}} — {{.Remarks}}{{end}}
+
+{{end}}{{end}}
 {{end}}
 {{end}}
 

--- a/gemaraconv/markdown/view.go
+++ b/gemaraconv/markdown/view.go
@@ -26,7 +26,7 @@ type markdownCatalogView struct {
 	ApplicabilityMatrixColumns []markdownApplicabilityColumn
 	ApplicabilityMatrixRows    []markdownApplicabilityMatrixRow
 	Extends                    []gemara.ArtifactMapping
-	Imports                    []gemara.MultiEntryMapping
+	Imports                    []markdownImportView
 	TOC                        bool
 	LineEnding                 string
 	Groups                     []markdownGroupView
@@ -64,6 +64,20 @@ type markdownTOCItem struct {
 	Anchor  string
 	Indent  int // 0 = group, 1 = control under group
 	Control bool
+}
+
+// markdownImportView is one source in the resolved Imports section.
+type markdownImportView struct {
+	// ReferenceId is the mapping-reference identifier.
+	ReferenceId string
+	// Title is the human-readable title from the MappingReference (may be empty).
+	Title string
+	// Url is the source URL from the MappingReference (may be empty).
+	Url string
+	// Remarks is optional prose from the MultiEntryMapping.
+	Remarks string
+	// Entries are the individual imported items.
+	Entries []gemara.ArtifactMapping
 }
 
 type markdownGroupView struct {
@@ -183,7 +197,7 @@ func buildMarkdownCatalogView(catalog *gemara.ControlCatalog, cfg Config, lexGlo
 		ApplicabilityMatrixColumns: applicabilityCols,
 		ApplicabilityMatrixRows:    applicabilityRows,
 		Extends:                    catalog.Extends,
-		Imports:                    catalog.Imports,
+		Imports:                    buildImportViews(catalog),
 		TOC:                        cfg.TOC,
 		LineEnding:                 cfg.LineEnding,
 		Groups:                     groups,
@@ -192,6 +206,32 @@ func buildMarkdownCatalogView(catalog *gemara.ControlCatalog, cfg Config, lexGlo
 		NumARs:                     numARs,
 		LexiconGlossary:            lexGlossary,
 	}
+}
+
+// buildImportViews resolves each Import's ReferenceId against Metadata.MappingReferences
+// to populate the title and URL for the rendered imports section.
+func buildImportViews(catalog *gemara.ControlCatalog) []markdownImportView {
+	if len(catalog.Imports) == 0 {
+		return nil
+	}
+	refMap := make(map[string]gemara.MappingReference, len(catalog.Metadata.MappingReferences))
+	for _, ref := range catalog.Metadata.MappingReferences {
+		refMap[ref.Id] = ref
+	}
+	views := make([]markdownImportView, len(catalog.Imports))
+	for i, imp := range catalog.Imports {
+		v := markdownImportView{
+			ReferenceId: imp.ReferenceId,
+			Remarks:     imp.Remarks,
+			Entries:     imp.Entries,
+		}
+		if ref, ok := refMap[imp.ReferenceId]; ok {
+			v.Title = ref.Title
+			v.Url = ref.Url
+		}
+		views[i] = v
+	}
+	return views
 }
 
 // copyControlsWithSortedARs returns a deep copy of ctrls with AssessmentRequirements

--- a/gemaraconv/markdown_test.go
+++ b/gemaraconv/markdown_test.go
@@ -158,6 +158,7 @@ func TestCatalogToMarkdown_extendsImportsReplacedBy(t *testing.T) {
 			Author:        gemara.Actor{Name: "Author", Type: gemara.Human},
 			MappingReferences: []gemara.MappingReference{
 				{Id: "ext", Title: "External", Version: "1", Url: "https://example.com"},
+				{Id: "imp", Title: "Imported Catalog", Version: "2", Url: "https://example.com/imported"},
 			},
 		},
 		Title: "Complex",
@@ -232,7 +233,10 @@ func TestCatalogToMarkdown_extendsImportsReplacedBy(t *testing.T) {
 	assert.Contains(t, s, "## Extends")
 	assert.Contains(t, s, "- base — extends base")
 	assert.Contains(t, s, "## Imports")
-	assert.Contains(t, s, "**imp**")
+	assert.Contains(t, s, "### imp: Imported Catalog")
+	assert.Contains(t, s, "imported")
+	assert.Contains(t, s, "**Source:** [https://example.com/imported](https://example.com/imported)")
+	assert.Contains(t, s, "#### e1 — r1")
 	assert.Contains(t, s, "### Mapping References")
 	assert.NotContains(t, s, "### C-HIDDEN")
 	assert.Contains(t, s, "### C1: Control one")


### PR DESCRIPTION
The table was looking pretty wonky, so this renders imports as subsections instead