### PR TITLE
feat: add OSCAL Assessment Results conversion for EvaluationLog

### DIFF
--- a/.github/workflows/oscal-test.yml
+++ b/.github/workflows/oscal-test.yml
@@ -42,3 +42,10 @@ jobs:
         uses: oscal-club/oscal-cli-action@6a8b6368885714e46fa1d4a65a6ce665902e08b7 # v2.1.0
         with:
           args: validate ./artifacts/guidance.json
+      - name: Validate OSCAL assessment results
+        # TODO(oscal-ar): Enable full constraint validation once upstream
+        # oscal-cli constraints for assessment-results are verified against
+        # Gemara-generated documents. Structural validation still runs.
+        uses: oscal-club/oscal-cli-action@6a8b6368885714e46fa1d4a65a6ce665902e08b7 # v2.1.0
+        with:
+          args: validate --disable-constraint-validation ./artifacts/assessment-results.json

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ oscal-export:
 	@mkdir -p artifacts
 	@go run ./cmd/oscalexport catalog ./test-data/good-osps.yml --output ./artifacts/catalog.json
 	@go run ./cmd/oscalexport guidance ./test-data/good-aigf.yaml --catalog-output ./artifacts/guidance.json --profile-output ./artifacts/profile.json
+	@go run ./cmd/oscalexport evaluation ./test-data/good-evaluation-log.yaml --output ./artifacts/assessment-results.json --catalog ./test-data/good-osps.yml
 
 help:
 	@echo "make targets:"

--- a/README.md
+++ b/README.md
@@ -185,11 +185,11 @@ func main() {
     }
 
     // Convert EvaluationLog to SARIF
-    evaluationLog := &gemara.EvaluationLog{
+    evaluationLog := gemara.EvaluationLog{
         // ... populate evaluation log ...
     }
 
-    sarifBytes, err := gemaraconv.EvaluationLog(evaluationLog).ToSARIF("path/to/artifact.md", catalog)
+    sarifBytes, err := gemaraconv.EvaluationLog(evaluationLog).ToSARIF(gemaraconv.WithArtifactURI("file:///path/to/artifact.md"), gemaraconv.WithCatalog(catalog))
     if err != nil {
         panic(err)
     }

--- a/cmd/oscalexport/export/export.go
+++ b/cmd/oscalexport/export/export.go
@@ -49,7 +49,7 @@ func Guidance(path string, args []string) error {
 	}
 	relativeCatalogPath = filepath.ToSlash(relativeCatalogPath)
 
-	catalog, profile, err := gemaraconv.GuidanceCatalog(guidanceDocument).ToOSCAL(relativeCatalogPath)
+	catalog, profile, err := gemaraconv.GuidanceCatalog(*guidanceDocument).ToOSCAL(relativeCatalogPath)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func Catalog(path string, args []string) error {
 		return err
 	}
 
-	oscalCatalog, err := gemaraconv.ControlCatalog(catalog).ToOSCAL(gemaraconv.WithControlHref(defaultControlHrefFormat))
+	oscalCatalog, err := gemaraconv.ControlCatalog(*catalog).ToOSCAL(gemaraconv.WithControlHref(defaultControlHrefFormat))
 	if err != nil {
 		return err
 	}

--- a/cmd/oscalexport/export/export.go
+++ b/cmd/oscalexport/export/export.go
@@ -91,6 +91,43 @@ func Catalog(path string, args []string) error {
 	return WriteOSCALFile(oscalModel, *outputFile)
 }
 
+func Evaluation(path string, args []string) error {
+	cmd := flag.NewFlagSet("evaluation", flag.ExitOnError)
+	outputFile := cmd.String("output", "assessment-results.json", "Path to output file")
+	importApHref := cmd.String("import-ap", "#", "URI referencing the governing assessment plan")
+	catalogPath := cmd.String("catalog", "", "Optional path to a ControlCatalog for enrichment")
+	if err := cmd.Parse(args); err != nil {
+		return err
+	}
+
+	log, err := gemara.Load[gemara.EvaluationLog](context.Background(), &fetcher.File{}, path)
+	if err != nil {
+		return err
+	}
+
+	var opts []gemaraconv.EvalOption
+	opts = append(opts, gemaraconv.WithImportApHref(*importApHref))
+
+	if *catalogPath != "" {
+		catalog, err := gemara.Load[gemara.ControlCatalog](context.Background(), &fetcher.File{}, *catalogPath)
+		if err != nil {
+			return fmt.Errorf("loading catalog %s: %w", *catalogPath, err)
+		}
+		opts = append(opts, gemaraconv.WithCatalog(catalog))
+	}
+
+	ar, err := gemaraconv.EvaluationLogToOSCALAssessmentResults(*log, opts...)
+	if err != nil {
+		return err
+	}
+
+	oscalModel := oscalTypes.OscalModels{
+		AssessmentResults: &ar,
+	}
+
+	return WriteOSCALFile(oscalModel, *outputFile)
+}
+
 func WriteOSCALFile(model oscalTypes.OscalModels, outputFile string) error {
 	oscalJSON, err := json.MarshalIndent(model, "", "  ")
 	if err != nil {

--- a/cmd/oscalexport/export/export_test.go
+++ b/cmd/oscalexport/export/export_test.go
@@ -125,3 +125,90 @@ controls:
 		require.ErrorContains(t, err, "string was used where mapping is expected")
 	})
 }
+
+func TestEvaluation(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mockYAML := `
+metadata:
+  id: test-eval
+  type: EvaluationLog
+  gemara-version: v1.0.0
+  version: "1.0.0"
+  date: "2025-01-01T00:00:00Z"
+  author:
+    name: test-tool
+    type: Software
+    version: "1.0.0"
+result: Failed
+target:
+  id: sys-1
+  name: Test System
+  type: Software
+evaluations:
+  - name: Test Control
+    result: Failed
+    message: control failed
+    control:
+      entry-id: CTRL-1
+    assessment-logs:
+      - requirement:
+          entry-id: REQ-1
+        description: verify requirement
+        result: Failed
+        message: requirement not met
+        steps-executed: 1
+        start: "2025-01-01T00:00:00Z"
+`
+	inputFilePath := filepath.Join(tempDir, "evaluation.yaml")
+	require.NoError(t, os.WriteFile(inputFilePath, []byte(mockYAML), 0600))
+
+	t.Run("Success/Defaults", func(t *testing.T) {
+		outputFilePath := filepath.Join(t.TempDir(), "assessment-results.json")
+		args := []string{"--output", outputFilePath}
+		err := Evaluation(inputFilePath, args)
+		require.NoError(t, err)
+
+		var model oscal.OscalModels
+		data, err := os.ReadFile(outputFilePath)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(data, &model))
+		require.NotNil(t, model.AssessmentResults)
+		assert.Contains(t, model.AssessmentResults.Metadata.Title, "test-eval")
+		require.Len(t, model.AssessmentResults.Results, 1)
+	})
+
+	t.Run("Success/WithImportAp", func(t *testing.T) {
+		outputFilePath := filepath.Join(t.TempDir(), "assessment-results.json")
+		args := []string{"--output", outputFilePath, "--import-ap", "#my-ap"}
+		err := Evaluation(inputFilePath, args)
+		require.NoError(t, err)
+
+		var model oscal.OscalModels
+		data, err := os.ReadFile(outputFilePath)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(data, &model))
+		assert.Equal(t, "#my-ap", model.AssessmentResults.ImportAp.Href)
+	})
+
+	t.Run("Failure/NotExists", func(t *testing.T) {
+		err := Evaluation("non-existent-file.yaml", []string{})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("Failure/InvalidInput", func(t *testing.T) {
+		failYAMLPath := filepath.Join(t.TempDir(), "fail.yaml")
+		require.NoError(t, os.WriteFile(failYAMLPath, []byte("fail"), 0600))
+		err := Evaluation(failYAMLPath, []string{})
+		require.ErrorContains(t, err, "string was used where mapping is expected")
+	})
+
+	t.Run("Failure/InvalidCatalogPath", func(t *testing.T) {
+		outputFilePath := filepath.Join(t.TempDir(), "assessment-results.json")
+		args := []string{"--output", outputFilePath, "--catalog", "non-existent-catalog.yaml"}
+		err := Evaluation(inputFilePath, args)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+}

--- a/cmd/oscalexport/main.go
+++ b/cmd/oscalexport/main.go
@@ -14,7 +14,7 @@ func main() {
 
 	if len(args) < 2 {
 		fmt.Println("Usage: oscal_exporter <subcommand> <path> [flags]")
-		fmt.Println("Available subcommands: guidance, catalog")
+		fmt.Println("Available subcommands: guidance, catalog, evaluation")
 		os.Exit(1)
 	}
 
@@ -27,6 +27,8 @@ func main() {
 		err = export.Guidance(path, subcommandArgs)
 	case "catalog":
 		err = export.Catalog(path, subcommandArgs)
+	case "evaluation":
+		err = export.Evaluation(path, subcommandArgs)
 	default:
 		fmt.Printf("Unknown subcommand: %s\n", subcommand)
 		os.Exit(1)

--- a/gemaraconv/assessment_results.go
+++ b/gemaraconv/assessment_results.go
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gemaraconv
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/defenseunicorns/go-oscal/src/pkg/uuid"
+	oscal "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
+	"github.com/gemaraproj/go-gemara"
+	oscalUtils "github.com/gemaraproj/go-gemara/internal/oscal"
+)
+
+// EvaluationLogToOSCALAssessmentResults converts a Gemara EvaluationLog into an
+// OSCAL Assessment Results document.
+//
+// Use WithImportApHref to set the assessment plan reference (defaults to "#").
+// Use WithCatalog to enrich findings with control titles and requirement text.
+func EvaluationLogToOSCALAssessmentResults(log gemara.EvaluationLog, opts ...EvalOption) (oscal.AssessmentResults, error) {
+	options := defaultEvalOpts()
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	authorPartyUUID := uuid.NewUUID()
+	metadata := createAssessmentResultsMetadata(log, authorPartyUUID)
+
+	result, err := evaluationLogToResult(log, options.catalog, authorPartyUUID)
+	if err != nil {
+		return oscal.AssessmentResults{}, fmt.Errorf("converting evaluation log %q: %w", log.Metadata.Id, err)
+	}
+
+	return oscal.AssessmentResults{
+		UUID:       uuid.NewUUID(),
+		Metadata:   metadata,
+		ImportAp:   oscal.ImportAp{Href: options.importApHref},
+		Results:    []oscal.Result{result},
+		BackMatter: mappingToBackMatter(log.Metadata.MappingReferences),
+	}, nil
+}
+
+func evaluationLogToResult(log gemara.EvaluationLog, catalog *gemara.ControlCatalog, authorPartyUUID string) (oscal.Result, error) {
+	now := time.Now()
+	start := oscalUtils.GetTimeWithFallback(string(log.Metadata.Date), now)
+
+	origin := buildOrigin(log.Metadata.Author, authorPartyUUID)
+
+	controlIds := collectControlIds(log)
+	reviewedControls := buildReviewedControls(controlIds)
+
+	var observations []oscal.Observation
+	var findings []oscal.Finding
+	var logEntries []oscal.AssessmentLogEntry
+
+	for _, eval := range log.Evaluations {
+		if eval == nil {
+			continue
+		}
+
+		finding := buildFinding(eval, catalog, origin)
+		var relatedObs []oscal.RelatedObservation
+
+		for _, alog := range eval.AssessmentLogs {
+			if alog == nil {
+				continue
+			}
+
+			obs := buildObservation(alog, eval, origin, start)
+			observations = append(observations, obs)
+			relatedObs = append(relatedObs, oscal.RelatedObservation{ObservationUuid: obs.UUID})
+
+			entry := buildLogEntry(alog, eval, authorPartyUUID, start)
+			logEntries = append(logEntries, entry)
+		}
+
+		if len(relatedObs) > 0 {
+			finding.RelatedObservations = &relatedObs
+		}
+		findings = append(findings, finding)
+	}
+
+	title := fmt.Sprintf("Evaluation: %s", log.Metadata.Id)
+
+	targetItem := buildTargetInventoryItem(log.Target)
+	localDefs := oscal.LocalDefinitions{
+		InventoryItems: &[]oscal.InventoryItem{targetItem},
+	}
+
+	result := oscal.Result{
+		UUID:             uuid.NewUUID(),
+		Title:            title,
+		Description:      fmt.Sprintf("Results from Gemara EvaluationLog %s", log.Metadata.Id),
+		Start:            start,
+		ReviewedControls: reviewedControls,
+		Observations:     oscalUtils.NilIfEmpty(observations),
+		Findings:         oscalUtils.NilIfEmpty(findings),
+		LocalDefinitions: &localDefs,
+		Props: &[]oscal.Property{
+			{
+				Name:  "aggregate-result",
+				Value: log.Result.String(),
+				Ns:    oscalUtils.GemaraNamespace,
+			},
+		},
+	}
+
+	if len(logEntries) > 0 {
+		result.AssessmentLog = &oscal.AssessmentLog{Entries: logEntries}
+	}
+
+	return result, nil
+}
+
+func createAssessmentResultsMetadata(log gemara.EvaluationLog, authorPartyUUID string) oscal.Metadata {
+	version := log.Metadata.Version
+	if version == "" {
+		version = oscalUtils.DefaultOSCALVersion
+	}
+
+	now := time.Now()
+	published := oscalUtils.GetTime(string(log.Metadata.Date))
+
+	metadata := oscal.Metadata{
+		Title:        fmt.Sprintf("Assessment Results: %s", log.Metadata.Id),
+		OscalVersion: oscal.Version,
+		Version:      version,
+		Published:    published,
+		LastModified: now,
+	}
+
+	if log.Metadata.Author.Name != "" {
+		authorRole := oscal.Role{
+			ID:    "assessor",
+			Title: "Assessor",
+		}
+		party := oscal.Party{
+			UUID: authorPartyUUID,
+			Type: mapPartyType(log.Metadata.Author.Type),
+			Name: log.Metadata.Author.Name,
+		}
+		metadata.Roles = &[]oscal.Role{authorRole}
+		metadata.Parties = &[]oscal.Party{party}
+		metadata.ResponsibleParties = &[]oscal.ResponsibleParty{
+			{RoleId: authorRole.ID, PartyUuids: []string{party.UUID}},
+		}
+	}
+
+	return metadata
+}
+
+func buildOrigin(author gemara.Actor, partyUUID string) oscal.Origin {
+	return oscal.Origin{
+		Actors: []oscal.OriginActor{
+			{
+				ActorUuid: partyUUID,
+				Type:      mapActorType(author.Type),
+				RoleId:    "assessor",
+			},
+		},
+	}
+}
+
+func buildReviewedControls(controlIds []string) oscal.ReviewedControls {
+	selectors := make([]oscal.AssessedControlsSelectControlById, 0, len(controlIds))
+	for _, id := range controlIds {
+		selectors = append(selectors, oscal.AssessedControlsSelectControlById{ControlId: id})
+	}
+	return oscal.ReviewedControls{
+		ControlSelections: []oscal.AssessedControls{
+			{IncludeControls: &selectors},
+		},
+	}
+}
+
+func buildFinding(eval *gemara.ControlEvaluation, catalog *gemara.ControlCatalog, origin oscal.Origin) oscal.Finding {
+	controlId := eval.Control.EntryId
+	status := mapResultToObjectiveStatus(eval.Result)
+
+	description := eval.Message
+	if description == "" {
+		description = fmt.Sprintf("Evaluation of control %s", controlId)
+	}
+
+	title := eval.Name
+	if catalog != nil {
+		control, _ := findControlAndRequirement(catalog, controlId, "")
+		if control != nil && control.Title != "" {
+			title = control.Title
+		}
+	}
+	if title == "" {
+		title = controlId
+	}
+	title = sanitizeTitle(title)
+
+	return oscal.Finding{
+		UUID:        uuid.NewUUID(),
+		Title:       title,
+		Description: description,
+		Origins:     &[]oscal.Origin{origin},
+		Target: oscal.FindingTarget{
+			Type:     "objective-id",
+			TargetId: controlId,
+			Status:   status,
+		},
+	}
+}
+
+func buildObservation(alog *gemara.AssessmentLog, eval *gemara.ControlEvaluation, origin oscal.Origin, fallback time.Time) oscal.Observation {
+	collected := oscalUtils.GetTimeWithFallback(string(alog.Start), fallback)
+
+	description := alog.Description
+	if description == "" {
+		description = alog.Message
+	}
+	if description == "" {
+		description = fmt.Sprintf("Assessment of requirement %s", alog.Requirement.EntryId)
+	}
+
+	methods := []string{"EXAMINE"}
+	if alog.StepsExecuted > 0 {
+		methods = []string{"TEST"}
+	}
+
+	obs := oscal.Observation{
+		UUID:        uuid.NewUUID(),
+		Description: description,
+		Collected:   collected,
+		Methods:     methods,
+		Origins:     &[]oscal.Origin{origin},
+		Props: &[]oscal.Property{
+			{
+				Name:  "result",
+				Value: alog.Result.String(),
+				Ns:    oscalUtils.GemaraNamespace,
+			},
+			{
+				Name:  "requirement-id",
+				Value: alog.Requirement.EntryId,
+				Ns:    oscalUtils.GemaraNamespace,
+			},
+			{
+				Name:  "control-id",
+				Value: eval.Control.EntryId,
+				Ns:    oscalUtils.GemaraNamespace,
+			},
+		},
+	}
+
+	if alog.Recommendation != "" {
+		obs.Remarks = alog.Recommendation
+	}
+
+	return obs
+}
+
+func buildLogEntry(alog *gemara.AssessmentLog, eval *gemara.ControlEvaluation, partyUUID string, fallback time.Time) oscal.AssessmentLogEntry {
+	start := oscalUtils.GetTimeWithFallback(string(alog.Start), fallback)
+
+	title := fmt.Sprintf("%s / %s", eval.Control.EntryId, alog.Requirement.EntryId)
+
+	entry := oscal.AssessmentLogEntry{
+		UUID:        uuid.NewUUID(),
+		Title:       title,
+		Start:       start,
+		Description: alog.Description,
+		LoggedBy: &[]oscal.LoggedBy{
+			{PartyUuid: partyUUID, RoleId: "assessor"},
+		},
+	}
+
+	if end := oscalUtils.GetTime(string(alog.End)); end != nil {
+		entry.End = end
+	}
+
+	return entry
+}
+
+func buildTargetInventoryItem(target gemara.Resource) oscal.InventoryItem {
+	description := target.Description
+	if description == "" {
+		description = target.Name
+	}
+
+	return oscal.InventoryItem{
+		UUID:        uuid.NewUUID(),
+		Description: description,
+		Props: &[]oscal.Property{
+			{
+				Name:  "gemara-resource-id",
+				Value: target.Id,
+				Ns:    oscalUtils.GemaraNamespace,
+			},
+			{
+				Name:  "name",
+				Value: target.Name,
+				Ns:    oscalUtils.GemaraNamespace,
+			},
+		},
+	}
+}
+
+func collectControlIds(log gemara.EvaluationLog) []string {
+	seen := make(map[string]struct{})
+	var ids []string
+	for _, eval := range log.Evaluations {
+		if eval == nil {
+			continue
+		}
+		id := eval.Control.EntryId
+		if _, exists := seen[id]; !exists {
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func mapResultToObjectiveStatus(r gemara.Result) oscal.ObjectiveStatus {
+	switch r {
+	case gemara.Passed:
+		return oscal.ObjectiveStatus{State: "satisfied"}
+	case gemara.Failed:
+		return oscal.ObjectiveStatus{State: "not-satisfied"}
+	default:
+		return oscal.ObjectiveStatus{
+			State:  "not-satisfied",
+			Reason: r.String(),
+		}
+	}
+}
+
+// sanitizeTitle collapses newlines and surrounding whitespace into a single
+// space so the value satisfies the OSCAL StringDatatype pattern (^[^\n]+$).
+func sanitizeTitle(s string) string {
+	parts := strings.Fields(s)
+	return strings.Join(parts, " ")
+}
+
+func mapActorType(t gemara.EntityType) string {
+	switch t {
+	case gemara.Human:
+		return "person"
+	default:
+		return "tool"
+	}
+}
+
+func mapPartyType(t gemara.EntityType) string {
+	switch t {
+	case gemara.Human:
+		return "person"
+	default:
+		return "organization"
+	}
+}

--- a/gemaraconv/assessment_results_test.go
+++ b/gemaraconv/assessment_results_test.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gemaraconv
+
+import (
+	"encoding/json"
+	"testing"
+
+	oscal "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
+	"github.com/gemaraproj/go-gemara"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testImportApHref = "#6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+func TestEvaluationLogToOSCALAssessmentResults(t *testing.T) {
+	log := makeEvaluationLog(gemara.Actor{
+		Name:    "test-tool",
+		Uri:     "https://github.com/test/tool",
+		Version: "1.0.0",
+		Type:    gemara.Software,
+	}, []*gemara.AssessmentLog{
+		makeAssessmentLog("REQ-1", "check first requirement", gemara.Failed, "requirement not met", nil),
+		makeAssessmentLog("REQ-2", "check second requirement", gemara.Passed, "", nil),
+	})
+	log.Metadata.Id = "eval-001"
+	log.Target = gemara.Resource{Id: "sys-1", Name: "Test System", Type: gemara.Software}
+
+	ar, err := EvaluationLogToOSCALAssessmentResults(log, WithImportApHref(testImportApHref))
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, ar.UUID)
+	assert.Equal(t, testImportApHref, ar.ImportAp.Href)
+	assert.Contains(t, ar.Metadata.Title, "eval-001")
+	require.Len(t, ar.Results, 1)
+
+	result := ar.Results[0]
+	assert.Contains(t, result.Title, "eval-001")
+	require.NotNil(t, result.Findings)
+	require.NotNil(t, result.Observations)
+	require.Len(t, *result.Findings, 1)
+	require.Len(t, *result.Observations, 2)
+
+	finding := (*result.Findings)[0]
+	assert.Equal(t, "CTRL-1", finding.Target.TargetId)
+	assert.Equal(t, "objective-id", finding.Target.Type)
+
+	require.NotNil(t, result.ReviewedControls.ControlSelections)
+	require.Len(t, result.ReviewedControls.ControlSelections, 1)
+	sel := result.ReviewedControls.ControlSelections[0]
+	require.NotNil(t, sel.IncludeControls)
+	require.Len(t, *sel.IncludeControls, 1)
+	assert.Equal(t, "CTRL-1", (*sel.IncludeControls)[0].ControlId)
+
+	assertValidJSON(t, ar)
+}
+
+func TestEvaluationLogToOSCALAssessmentResults_WithCatalogEnrichment(t *testing.T) {
+	catalog := makeCatalog("CTRL-1", "Access Control", "Enforce access controls", "REQ-1", "Verify access is restricted", "Use RBAC")
+
+	log := makeEvaluationLog(gemara.Actor{Name: "tool", Type: gemara.Software}, []*gemara.AssessmentLog{
+		makeAssessmentLog("REQ-1", "check access", gemara.Failed, "access unrestricted", nil),
+	})
+	log.Metadata.Id = "eval-enriched"
+
+	ar, err := EvaluationLogToOSCALAssessmentResults(log, WithImportApHref(testImportApHref), WithCatalog(catalog))
+	require.NoError(t, err)
+	require.Len(t, ar.Results, 1)
+
+	finding := (*ar.Results[0].Findings)[0]
+	assert.Equal(t, "Access Control", finding.Title)
+	assertValidJSON(t, ar)
+}
+
+func TestEvaluationLogToOSCALAssessmentResults_ResultMapping(t *testing.T) {
+	tests := []struct {
+		result      gemara.Result
+		wantState   string
+		wantReason  string
+		description string
+	}{
+		{gemara.Passed, "satisfied", "", "passed maps to satisfied"},
+		{gemara.Failed, "not-satisfied", "", "failed maps to not-satisfied"},
+		{gemara.NeedsReview, "not-satisfied", "Needs Review", "needs-review maps to not-satisfied with reason"},
+		{gemara.Unknown, "not-satisfied", "Unknown", "unknown maps to not-satisfied with reason"},
+		{gemara.NotApplicable, "not-satisfied", "Not Applicable", "not-applicable maps to not-satisfied with reason"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			log := makeEvaluationLog(gemara.Actor{Name: "tool", Type: gemara.Software}, []*gemara.AssessmentLog{
+				makeAssessmentLog("REQ-1", "check", tt.result, "", nil),
+			})
+			log.Evaluations[0].Result = tt.result
+
+			ar, err := EvaluationLogToOSCALAssessmentResults(log)
+			require.NoError(t, err)
+
+			finding := (*ar.Results[0].Findings)[0]
+			assert.Equal(t, tt.wantState, finding.Target.Status.State)
+			assert.Equal(t, tt.wantReason, finding.Target.Status.Reason)
+		})
+	}
+}
+
+func TestEvaluationLogToOSCALAssessmentResults_DefaultImportApHref(t *testing.T) {
+	log := makeEvaluationLog(gemara.Actor{Name: "tool", Type: gemara.Software}, []*gemara.AssessmentLog{
+		makeAssessmentLog("REQ-1", "check", gemara.Passed, "", nil),
+	})
+
+	ar, err := EvaluationLogToOSCALAssessmentResults(log)
+	require.NoError(t, err)
+	assert.Equal(t, "#", ar.ImportAp.Href)
+}
+
+func TestEvaluationLogToOSCALAssessmentResults_ObservationMethod(t *testing.T) {
+	log := makeEvaluationLog(gemara.Actor{Name: "tool", Type: gemara.Software}, []*gemara.AssessmentLog{
+		makeAssessmentLog("REQ-1", "automated check", gemara.Passed, "", nil),
+	})
+
+	ar, err := EvaluationLogToOSCALAssessmentResults(log)
+	require.NoError(t, err)
+
+	obs := (*ar.Results[0].Observations)[0]
+	assert.Contains(t, obs.Methods, "TEST")
+}
+
+func TestEvaluationLogToOSCALAssessmentResults_AssessmentLogEntries(t *testing.T) {
+	log := makeEvaluationLog(gemara.Actor{Name: "tool", Type: gemara.Software}, []*gemara.AssessmentLog{
+		makeAssessmentLog("REQ-1", "first check", gemara.Passed, "", nil),
+		makeAssessmentLog("REQ-2", "second check", gemara.Failed, "broke", nil),
+	})
+
+	ar, err := EvaluationLogToOSCALAssessmentResults(log)
+	require.NoError(t, err)
+
+	result := ar.Results[0]
+	require.NotNil(t, result.AssessmentLog)
+	require.Len(t, result.AssessmentLog.Entries, 2)
+	assert.Contains(t, result.AssessmentLog.Entries[0].Title, "REQ-1")
+	assert.Contains(t, result.AssessmentLog.Entries[1].Title, "REQ-2")
+}
+
+func TestEvaluationLogToOSCALAssessmentResults_TargetInventoryItem(t *testing.T) {
+	log := makeEvaluationLog(gemara.Actor{Name: "tool", Type: gemara.Software}, []*gemara.AssessmentLog{
+		makeAssessmentLog("REQ-1", "check", gemara.Passed, "", nil),
+	})
+	log.Target = gemara.Resource{Id: "my-sys", Name: "Production System", Description: "The prod system"}
+
+	ar, err := EvaluationLogToOSCALAssessmentResults(log)
+	require.NoError(t, err)
+
+	result := ar.Results[0]
+	require.NotNil(t, result.LocalDefinitions)
+	require.NotNil(t, result.LocalDefinitions.InventoryItems)
+	require.Len(t, *result.LocalDefinitions.InventoryItems, 1)
+
+	item := (*result.LocalDefinitions.InventoryItems)[0]
+	assert.Equal(t, "The prod system", item.Description)
+	require.NotNil(t, item.Props)
+	props := *item.Props
+	assert.Equal(t, "my-sys", props[0].Value)
+	assert.Equal(t, "Production System", props[1].Value)
+}
+
+func TestEvaluationLogConverter_ToOSCALAssessmentResults(t *testing.T) {
+	log := makeEvaluationLog(gemara.Actor{Name: "tool", Type: gemara.Software},
+		[]*gemara.AssessmentLog{makeAssessmentLog("REQ-1", "check", gemara.Passed, "", nil)})
+	log.Metadata.Id = "eval-converter"
+
+	converter := EvaluationLog(log)
+	ar, err := converter.ToOSCALAssessmentResults(WithImportApHref(testImportApHref))
+	require.NoError(t, err)
+	require.Len(t, ar.Results, 1)
+	assert.Contains(t, ar.Results[0].Title, "eval-converter")
+}
+
+func TestEvaluationLogToOSCALAssessmentResults_BackMatter(t *testing.T) {
+	log := makeEvaluationLog(gemara.Actor{Name: "tool", Type: gemara.Software}, []*gemara.AssessmentLog{
+		makeAssessmentLog("REQ-1", "check", gemara.Passed, "", nil),
+	})
+	log.Metadata.MappingReferences = []gemara.MappingReference{
+		{
+			Id:          "CNSC",
+			Title:       "Cloud Native Security Controls",
+			Version:     "1.0.0",
+			Description: "CNCF security controls catalog",
+			Url:         "https://example.com/cnsc",
+		},
+	}
+
+	ar, err := EvaluationLogToOSCALAssessmentResults(log)
+	require.NoError(t, err)
+
+	require.NotNil(t, ar.BackMatter)
+	require.NotNil(t, ar.BackMatter.Resources)
+	require.Len(t, *ar.BackMatter.Resources, 1)
+
+	resource := (*ar.BackMatter.Resources)[0]
+	assert.Equal(t, "Cloud Native Security Controls", resource.Title)
+	assert.NotEmpty(t, resource.UUID)
+	assertValidJSON(t, ar)
+}
+
+func TestEvaluationLogToOSCALAssessmentResults_NoBackMatterWhenEmpty(t *testing.T) {
+	log := makeEvaluationLog(gemara.Actor{Name: "tool", Type: gemara.Software}, []*gemara.AssessmentLog{
+		makeAssessmentLog("REQ-1", "check", gemara.Passed, "", nil),
+	})
+
+	ar, err := EvaluationLogToOSCALAssessmentResults(log)
+	require.NoError(t, err)
+	assert.Nil(t, ar.BackMatter)
+}
+
+func TestEvaluationLogToOSCALAssessmentResults_PartyUUIDConsistency(t *testing.T) {
+	log := makeEvaluationLog(gemara.Actor{Name: "tool", Type: gemara.Software}, []*gemara.AssessmentLog{
+		makeAssessmentLog("REQ-1", "check", gemara.Passed, "", nil),
+	})
+
+	ar, err := EvaluationLogToOSCALAssessmentResults(log)
+	require.NoError(t, err)
+
+	require.NotNil(t, ar.Metadata.Parties)
+	metadataPartyUUID := (*ar.Metadata.Parties)[0].UUID
+
+	result := ar.Results[0]
+	require.NotNil(t, result.Findings)
+	finding := (*result.Findings)[0]
+	require.NotNil(t, finding.Origins)
+	originActorUUID := (*finding.Origins)[0].Actors[0].ActorUuid
+
+	assert.Equal(t, metadataPartyUUID, originActorUUID, "metadata party UUID must match origin actor UUID")
+
+	require.NotNil(t, result.AssessmentLog)
+	loggedByUUID := (*result.AssessmentLog.Entries[0].LoggedBy)[0].PartyUuid
+	assert.Equal(t, metadataPartyUUID, loggedByUUID, "metadata party UUID must match log entry party UUID")
+}
+
+func TestMapActorType(t *testing.T) {
+	assert.Equal(t, "person", mapActorType(gemara.Human))
+	assert.Equal(t, "tool", mapActorType(gemara.Software))
+	assert.Equal(t, "tool", mapActorType(gemara.SoftwareAssisted))
+}
+
+func TestMapPartyType(t *testing.T) {
+	assert.Equal(t, "person", mapPartyType(gemara.Human))
+	assert.Equal(t, "organization", mapPartyType(gemara.Software))
+	assert.Equal(t, "organization", mapPartyType(gemara.SoftwareAssisted))
+}
+
+// Helpers
+
+func assertValidJSON(t *testing.T, ar oscal.AssessmentResults) {
+	t.Helper()
+	model := oscal.OscalModels{AssessmentResults: &ar}
+	data, err := json.MarshalIndent(model, "", "  ")
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	var roundtrip oscal.OscalModels
+	require.NoError(t, json.Unmarshal(data, &roundtrip))
+	require.NotNil(t, roundtrip.AssessmentResults)
+}

--- a/gemaraconv/catalog.go
+++ b/gemaraconv/catalog.go
@@ -10,7 +10,7 @@ import (
 )
 
 // CatalogToOSCAL converts a Gemara ControlCatalog to OSCAL Catalog format.
-func CatalogToOSCAL(catalog *gemara.ControlCatalog, opts ...GenerateOption) (oscal.Catalog, error) {
+func CatalogToOSCAL(catalog gemara.ControlCatalog, opts ...GenerateOption) (oscal.Catalog, error) {
 	options := generateOpts{}
 	for _, opt := range opts {
 		opt(&options)

--- a/gemaraconv/catalog_markdown.go
+++ b/gemaraconv/catalog_markdown.go
@@ -2,7 +2,6 @@ package gemaraconv
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gemaraproj/go-gemara"
 	"github.com/gemaraproj/go-gemara/gemaraconv/markdown"
@@ -13,11 +12,7 @@ type InlineLexiconTerm = markdown.InlineLexiconTerm
 
 // CatalogToMarkdown renders a ControlCatalog as Markdown using embedded templates.
 // Only controls whose state is LifecycleActive are included (TOC, body, and summary counts).
-func CatalogToMarkdown(ctx context.Context, catalog *gemara.ControlCatalog, opts ...MarkdownOption) ([]byte, error) {
-	if catalog == nil {
-		return nil, fmt.Errorf("catalog is nil")
-	}
-
+func CatalogToMarkdown(ctx context.Context, catalog gemara.ControlCatalog, opts ...MarkdownOption) ([]byte, error) {
 	o := defaultMarkdownOpts()
 	o.apply(opts...)
 

--- a/gemaraconv/catalog_test.go
+++ b/gemaraconv/catalog_test.go
@@ -12,14 +12,14 @@ import (
 
 var testCases = []struct {
 	name          string
-	catalog       *gemara.ControlCatalog
+	catalog       gemara.ControlCatalog
 	controlHREF   string
 	wantErr       bool
 	expectedTitle string
 }{
 	{
 		name: "Valid catalog with single control family",
-		catalog: &gemara.ControlCatalog{
+		catalog: gemara.ControlCatalog{
 			Metadata: gemara.Metadata{
 				Id:      "test-catalog",
 				Version: "devel",
@@ -52,7 +52,7 @@ var testCases = []struct {
 	},
 	{
 		name: "Valid catalog with multiple control families",
-		catalog: &gemara.ControlCatalog{
+		catalog: gemara.ControlCatalog{
 			Metadata: gemara.Metadata{
 				Id:      "test-catalog-multi",
 				Version: "devel",

--- a/gemaraconv/converters.go
+++ b/gemaraconv/converters.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package gemaraconv
 
 import (
@@ -9,26 +11,26 @@ import (
 
 // EvaluationLogConverter define a converter object for converting EvaluationLog.
 type EvaluationLogConverter struct {
-	log *gemara.EvaluationLog
+	log gemara.EvaluationLog
 }
 
 // EvaluationLog creates a new EvaluationLogConverter struct.
-func EvaluationLog(log *gemara.EvaluationLog) *EvaluationLogConverter {
+func EvaluationLog(log gemara.EvaluationLog) *EvaluationLogConverter {
 	return &EvaluationLogConverter{log: log}
 }
 
 // ToSARIF converts the EvaluationLog to SARIF format.
 func (c *EvaluationLogConverter) ToSARIF(artifactURI string, catalog *gemara.ControlCatalog) ([]byte, error) {
-	return ToSARIF(*c.log, artifactURI, catalog)
+	return ToSARIF(c.log, artifactURI, catalog)
 }
 
 // ControlCatalogConverter defines a converter for converting ControlCatalog.
 type ControlCatalogConverter struct {
-	catalog *gemara.ControlCatalog
+	catalog gemara.ControlCatalog
 }
 
 // ControlCatalog creates a new ControlCatalogConverter struct.
-func ControlCatalog(catalog *gemara.ControlCatalog) *ControlCatalogConverter {
+func ControlCatalog(catalog gemara.ControlCatalog) *ControlCatalogConverter {
 	return &ControlCatalogConverter{catalog: catalog}
 }
 
@@ -44,11 +46,11 @@ func (c *ControlCatalogConverter) ToMarkdown(ctx context.Context, opts ...Markdo
 
 // GuidanceCatalogConverter defines a converter for converting GuidanceCatalog.
 type GuidanceCatalogConverter struct {
-	guidance *gemara.GuidanceCatalog
+	guidance gemara.GuidanceCatalog
 }
 
 // GuidanceCatalog creates a new GuidanceCatalogConverter struct.
-func GuidanceCatalog(guidance *gemara.GuidanceCatalog) *GuidanceCatalogConverter {
+func GuidanceCatalog(guidance gemara.GuidanceCatalog) *GuidanceCatalogConverter {
 	return &GuidanceCatalogConverter{guidance: guidance}
 }
 

--- a/gemaraconv/converters.go
+++ b/gemaraconv/converters.go
@@ -20,8 +20,13 @@ func EvaluationLog(log gemara.EvaluationLog) *EvaluationLogConverter {
 }
 
 // ToSARIF converts the EvaluationLog to SARIF format.
-func (c *EvaluationLogConverter) ToSARIF(artifactURI string, catalog *gemara.ControlCatalog) ([]byte, error) {
-	return ToSARIF(c.log, artifactURI, catalog)
+func (c *EvaluationLogConverter) ToSARIF(opts ...EvalOption) ([]byte, error) {
+	return ToSARIF(c.log, opts...)
+}
+
+// ToOSCALAssessmentResults converts the EvaluationLog to an OSCAL Assessment Results document.
+func (c *EvaluationLogConverter) ToOSCALAssessmentResults(opts ...EvalOption) (oscal.AssessmentResults, error) {
+	return EvaluationLogToOSCALAssessmentResults(c.log, opts...)
 }
 
 // ControlCatalogConverter defines a converter for converting ControlCatalog.

--- a/gemaraconv/doc.go
+++ b/gemaraconv/doc.go
@@ -10,11 +10,11 @@
 //
 // Examples:
 //
-//	sarifBytes, err := gemaraconv.ToSARIF(&log, "file.md", catalog)
+//	sarifBytes, err := gemaraconv.ToSARIF(log, gemaraconv.WithArtifactURI("file.md"), gemaraconv.WithCatalog(catalog))
 //	oscalCatalog, err := gemaraconv.CatalogToOSCAL(catalog, gemaraconv.WithVersion("1.0"))
 //	md, err := gemaraconv.CatalogToMarkdown(ctx, catalog, gemaraconv.WithTOC(true), gemaraconv.WithLexiconAutolink(true))
 //	// Or pass list-shaped entries: WithInlineLexicon([]gemaraconv.InlineLexiconTerm{...})
-//	converter := gemaraconv.EvaluationLog(&log)
-//	sarifBytes, err := converter.ToSARIF("file.md", catalog)
+//	converter := gemaraconv.EvaluationLog(log)
+//	sarifBytes, err := converter.ToSARIF(gemaraconv.WithArtifactURI("file.md"), gemaraconv.WithCatalog(catalog))
 //	md, err := gemaraconv.ControlCatalog(catalog).ToMarkdown(ctx)
 package gemaraconv

--- a/gemaraconv/guidance.go
+++ b/gemaraconv/guidance.go
@@ -14,7 +14,7 @@ import (
 // GuidanceToOSCAL converts a Gemara GuidanceCatalog to both an OSCAL Catalog and Profile.
 // The catalog includes only the locally defined guidelines (categories), not imported ones.
 // The profile includes imports for both external guidelines and the local catalog.
-func GuidanceToOSCAL(g *gemara.GuidanceCatalog, guidanceDocHref string, opts ...GenerateOption) (oscal.Catalog, oscal.Profile, error) {
+func GuidanceToOSCAL(g gemara.GuidanceCatalog, guidanceDocHref string, opts ...GenerateOption) (oscal.Catalog, oscal.Profile, error) {
 	// The guidanceDocHref parameter specifies the location where the OSCAL Catalog
 	// will be saved, used to create the import reference in the Profile. This must
 	// be a relative or absolute URI that accurately reflects where the catalog file
@@ -116,7 +116,7 @@ func GuidanceToOSCAL(g *gemara.GuidanceCatalog, guidanceDocHref string, opts ...
 	return catalog, profile, nil
 }
 
-func createControlGroup(g *gemara.GuidanceCatalog, group gemara.Group, guidelines []gemara.Guideline, resourcesMap map[string]string) oscal.Group {
+func createControlGroup(g gemara.GuidanceCatalog, group gemara.Group, guidelines []gemara.Guideline, resourcesMap map[string]string) oscal.Group {
 	oscalGroup := oscal.Group{
 		Class: "family",
 		ID:    group.Id,
@@ -291,7 +291,7 @@ func guidelineToParts(guideline gemara.Guideline, controlId string, guidelineId 
 	return parts
 }
 
-func guidelineToControl(g *gemara.GuidanceCatalog, guideline gemara.Guideline, resourcesMap map[string]string) (oscal.Control, string) {
+func guidelineToControl(g gemara.GuidanceCatalog, guideline gemara.Guideline, resourcesMap map[string]string) (oscal.Control, string) {
 	controlId := oscalUtils.NormalizeControl(guideline.Id, false)
 
 	control := oscal.Control{

--- a/gemaraconv/guidance_test.go
+++ b/gemaraconv/guidance_test.go
@@ -38,7 +38,7 @@ func TestGuidanceToOSCAL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			catalog, profile, err := GuidanceToOSCAL(&tt.guidance, tt.catalogHref)
+			catalog, profile, err := GuidanceToOSCAL(tt.guidance, tt.catalogHref)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -283,7 +283,7 @@ func TestGuidanceToOSCAL_Catalog(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			catalog, _, err := GuidanceToOSCAL(&tt.guidance, "test-catalog.json")
+			catalog, _, err := GuidanceToOSCAL(tt.guidance, "test-catalog.json")
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -392,7 +392,7 @@ func TestGuidanceToOSCAL_Profile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, profile, err := GuidanceToOSCAL(&tt.guidance, "testHref", tt.options...)
+			_, profile, err := GuidanceToOSCAL(tt.guidance, "testHref", tt.options...)
 			require.NoError(t, err)
 			oscalDocument := oscalTypes.OscalModels{
 				Profile: &profile,

--- a/gemaraconv/markdown/render.go
+++ b/gemaraconv/markdown/render.go
@@ -17,11 +17,7 @@ var templatesFS embed.FS
 
 // CatalogToMarkdown renders a ControlCatalog as Markdown using embedded templates.
 // Only controls whose state is LifecycleActive are included (TOC, body, and summary counts).
-func CatalogToMarkdown(ctx context.Context, catalog *gemara.ControlCatalog, cfg Config) ([]byte, error) {
-	if catalog == nil {
-		return nil, fmt.Errorf("catalog is nil")
-	}
-
+func CatalogToMarkdown(ctx context.Context, catalog gemara.ControlCatalog, cfg Config) ([]byte, error) {
 	lineEnding := cfg.LineEnding
 	if lineEnding == "" {
 		lineEnding = "\n"

--- a/gemaraconv/markdown/render_test.go
+++ b/gemaraconv/markdown/render_test.go
@@ -14,12 +14,6 @@ func defaultRenderConfig() Config {
 	return Config{TOC: true, LineEnding: "\n", Metadata: true}
 }
 
-func TestCatalogToMarkdown_nilCatalog(t *testing.T) {
-	_, err := CatalogToMarkdown(context.Background(), nil, defaultRenderConfig())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "nil")
-}
-
 func TestAnchor(t *testing.T) {
 	assert.Equal(t, "section", Anchor(""))
 	assert.Equal(t, "hello-world", Anchor("Hello World"))
@@ -46,7 +40,7 @@ func TestCatalogToMarkdown_crlf(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_metadataBranches(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id:            "mid",
 			Type:          gemara.ControlCatalogArtifact,
@@ -81,7 +75,7 @@ func TestCatalogToMarkdown_metadataBranches(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_retiredAssessmentRequirement(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id: "x", Type: gemara.ControlCatalogArtifact, Description: "d", Author: gemara.Actor{Name: "a", Type: gemara.Human},
 		},
@@ -116,7 +110,7 @@ func TestCatalogToMarkdown_retiredAssessmentRequirement(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_guidelinesAndThreatsTables(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id: "x", Type: gemara.ControlCatalogArtifact, Description: "d", Author: gemara.Actor{Name: "a", Type: gemara.Human},
 		},
@@ -157,7 +151,7 @@ func TestCatalogToMarkdown_guidelinesAndThreatsTables(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_applicabilityMatrixImplicitColumns(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id:          "m",
 			Type:        gemara.ControlCatalogArtifact,
@@ -190,7 +184,7 @@ func TestCatalogToMarkdown_applicabilityMatrixImplicitColumns(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_applicabilityMatrix_noNewlineInTableRow(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id: "m", Type: gemara.ControlCatalogArtifact, Description: "d", Author: gemara.Actor{Name: "a", Type: gemara.Human},
 			ApplicabilityGroups: []gemara.Group{{Id: "L1", Title: "Level 1"}},
@@ -220,7 +214,7 @@ func TestCatalogToMarkdown_applicabilityMatrix_noNewlineInTableRow(t *testing.T)
 }
 
 func TestCatalogToMarkdown_ungroupedBucket(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id: "c", Type: gemara.ControlCatalogArtifact, GemaraVersion: "1.0", Description: "d",
 			Author: gemara.Actor{Name: "a", Type: gemara.Human},
@@ -242,7 +236,7 @@ func TestCatalogToMarkdown_ungroupedBucket(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_inlineLexiconPipeline(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id: "m", Type: gemara.ControlCatalogArtifact, Description: "d", Author: gemara.Actor{Name: "a", Type: gemara.Human},
 		},
@@ -264,7 +258,7 @@ func TestCatalogToMarkdown_inlineLexiconPipeline(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_lexiconAutolinkFromFile(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id: "m", Type: gemara.ControlCatalogArtifact, Description: "d", Author: gemara.Actor{Name: "a", Type: gemara.Human},
 			Lexicon: &gemara.ArtifactMapping{ReferenceId: "lex"},
@@ -284,7 +278,7 @@ func TestCatalogToMarkdown_lexiconAutolinkFromFile(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_lexiconResolveError(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id: "m", Type: gemara.ControlCatalogArtifact, Description: "d", Author: gemara.Actor{Name: "a", Type: gemara.Human},
 			Lexicon: &gemara.ArtifactMapping{ReferenceId: "nope"},
@@ -299,7 +293,7 @@ func TestCatalogToMarkdown_lexiconResolveError(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_inlineLexiconNormalizeError(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id: "m", Type: gemara.ControlCatalogArtifact, Description: "d", Author: gemara.Actor{Name: "a", Type: gemara.Human},
 		},
@@ -318,9 +312,9 @@ func TestMarkdownFuncMap_joinArtifactEntriesEmpty(t *testing.T) {
 	assert.Equal(t, "", join([]gemara.ArtifactMapping{}, " · "))
 }
 
-func minimalCatalog(t *testing.T) *gemara.ControlCatalog {
+func minimalCatalog(t *testing.T) gemara.ControlCatalog {
 	t.Helper()
-	return &gemara.ControlCatalog{
+	return gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id: "id1", Type: gemara.ControlCatalogArtifact, Version: "v1", Description: "One line.",
 			Author: gemara.Actor{Name: "Author", Type: gemara.Human},

--- a/gemaraconv/markdown/view.go
+++ b/gemaraconv/markdown/view.go
@@ -105,11 +105,7 @@ func buildLexiconGlossaryView(entries []lexiconEntry) []markdownLexiconGlossaryE
 	return out
 }
 
-func buildMarkdownCatalogView(catalog *gemara.ControlCatalog, cfg Config, lexGlossary []markdownLexiconGlossaryEntry) markdownCatalogView {
-	if catalog == nil {
-		return markdownCatalogView{LineEnding: cfg.LineEnding, LexiconGlossary: lexGlossary}
-	}
-
+func buildMarkdownCatalogView(catalog gemara.ControlCatalog, cfg Config, lexGlossary []markdownLexiconGlossaryEntry) markdownCatalogView {
 	known := make(map[string]struct{}, len(catalog.Groups))
 	for _, g := range catalog.Groups {
 		known[g.Id] = struct{}{}
@@ -210,7 +206,7 @@ func buildMarkdownCatalogView(catalog *gemara.ControlCatalog, cfg Config, lexGlo
 
 // buildImportViews resolves each Import's ReferenceId against Metadata.MappingReferences
 // to populate the title and URL for the rendered imports section.
-func buildImportViews(catalog *gemara.ControlCatalog) []markdownImportView {
+func buildImportViews(catalog gemara.ControlCatalog) []markdownImportView {
 	if len(catalog.Imports) == 0 {
 		return nil
 	}
@@ -254,7 +250,7 @@ func arIncludedInApplicabilityMatrix(ar gemara.AssessmentRequirement) bool {
 // applicabilityColumnIDs returns ordered applicability ids for matrix columns:
 // metadata applicability-groups order if present, else sorted union of applicability
 // on non-retired assessment requirements under active controls.
-func applicabilityColumnIDs(catalog *gemara.ControlCatalog) []string {
+func applicabilityColumnIDs(catalog gemara.ControlCatalog) []string {
 	if len(catalog.Metadata.ApplicabilityGroups) > 0 {
 		out := make([]string, 0, len(catalog.Metadata.ApplicabilityGroups))
 		for _, g := range catalog.Metadata.ApplicabilityGroups {
@@ -284,8 +280,8 @@ func applicabilityColumnIDs(catalog *gemara.ControlCatalog) []string {
 	return out
 }
 
-func buildApplicabilityMatrix(catalog *gemara.ControlCatalog, groups []markdownGroupView, enabled bool) (cols []markdownApplicabilityColumn, rows []markdownApplicabilityMatrixRow, show bool) {
-	if !enabled || catalog == nil {
+func buildApplicabilityMatrix(catalog gemara.ControlCatalog, groups []markdownGroupView, enabled bool) (cols []markdownApplicabilityColumn, rows []markdownApplicabilityMatrixRow, show bool) {
+	if !enabled {
 		return nil, nil, false
 	}
 	colIDs := applicabilityColumnIDs(catalog)

--- a/gemaraconv/markdown_test.go
+++ b/gemaraconv/markdown_test.go
@@ -23,16 +23,11 @@ func testDataFilePath(t *testing.T, name string) string {
 	return abs
 }
 
-func loadControlCatalogFromTestData(t *testing.T, name string) *gemara.ControlCatalog {
+func loadControlCatalogFromTestData(t *testing.T, name string) gemara.ControlCatalog {
 	t.Helper()
 	c, err := gemara.Load[gemara.ControlCatalog](context.Background(), &fetcher.File{}, filepath.Join("..", "test-data", name))
 	require.NoError(t, err, "load %s", name)
-	return c
-}
-
-func TestCatalogToMarkdown_nil(t *testing.T) {
-	_, err := CatalogToMarkdown(context.Background(), nil)
-	require.Error(t, err)
+	return *c
 }
 
 func TestCatalogToMarkdown_goodCCCYAML(t *testing.T) {
@@ -98,7 +93,7 @@ func TestCatalogToMarkdown_nestedGoodCCCYAML(t *testing.T) {
 	err := c.LoadNestedCatalog(context.Background(), &fetcher.File{}, filepath.Join("..", "test-data", "nested-good-ccc.yaml"), "catalog")
 	require.NoError(t, err)
 
-	out, err := CatalogToMarkdown(context.Background(), c)
+	out, err := CatalogToMarkdown(context.Background(), *c)
 	require.NoError(t, err)
 	s := string(out)
 
@@ -107,7 +102,7 @@ func TestCatalogToMarkdown_nestedGoodCCCYAML(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_ungrouped(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id:            "c",
 			Type:          gemara.ControlCatalogArtifact,
@@ -149,7 +144,7 @@ func TestCatalogToMarkdown_ungrouped(t *testing.T) {
 
 func TestCatalogToMarkdown_extendsImportsReplacedBy(t *testing.T) {
 	// test-data catalogs do not combine extends/imports/replaced-by; keep a focused synthetic case.
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id:            "full",
 			Type:          gemara.ControlCatalogArtifact,
@@ -279,7 +274,7 @@ func TestCatalogToMarkdown_withoutMetadata(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_applicabilityMatrix(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id:          "m",
 			Type:        gemara.ControlCatalogArtifact,
@@ -336,7 +331,7 @@ func TestCatalogToMarkdown_applicabilityMatrix_offByDefault(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_lexiconAutolink(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id:            "m",
 			Type:          gemara.ControlCatalogArtifact,
@@ -381,7 +376,7 @@ func TestCatalogToMarkdown_lexiconAutolink(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_lexiconAutolink_offByDefault(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id:          "m",
 			Type:        gemara.ControlCatalogArtifact,
@@ -404,7 +399,7 @@ func TestCatalogToMarkdown_lexiconAutolink_offByDefault(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_inlineLexicon(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id:            "m",
 			Type:          gemara.ControlCatalogArtifact,
@@ -429,7 +424,7 @@ func TestCatalogToMarkdown_inlineLexicon(t *testing.T) {
 }
 
 func TestCatalogToMarkdown_lexiconAutolink_resolveError(t *testing.T) {
-	catalog := &gemara.ControlCatalog{
+	catalog := gemara.ControlCatalog{
 		Metadata: gemara.Metadata{
 			Id:          "m",
 			Type:        gemara.ControlCatalogArtifact,

--- a/gemaraconv/metadata.go
+++ b/gemaraconv/metadata.go
@@ -61,7 +61,7 @@ func createMetadata(title string, version string, published *time.Time, canonica
 }
 
 // createMetadataFromGuidance creates OSCAL metadata from a GuidanceCatalog
-func createMetadataFromGuidance(guidance *gemara.GuidanceCatalog, opts generateOpts) (oscal.Metadata, error) {
+func createMetadataFromGuidance(guidance gemara.GuidanceCatalog, opts generateOpts) (oscal.Metadata, error) {
 	canonicalHref := ""
 	if opts.canonicalHref != "" {
 		canonicalHref = fmt.Sprintf(opts.canonicalHref, opts.version)
@@ -80,7 +80,7 @@ func createMetadataFromGuidance(guidance *gemara.GuidanceCatalog, opts generateO
 }
 
 // createMetadataFromCatalog creates OSCAL metadata from a ControlCatalog
-func createMetadataFromCatalog(catalog *gemara.ControlCatalog, opts generateOpts) (oscal.Metadata, error) {
+func createMetadataFromCatalog(catalog gemara.ControlCatalog, opts generateOpts) (oscal.Metadata, error) {
 	// Handle canonical HREF - prefer controlHREF for Catalog, fallback to canonicalHref
 	var canonicalHref string
 	if opts.controlHREF != "" {

--- a/gemaraconv/options.go
+++ b/gemaraconv/options.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package gemaraconv
 
 import "github.com/gemaraproj/go-gemara"
@@ -9,7 +11,7 @@ type generateOpts struct {
 	controlHREF   string
 }
 
-func (g *generateOpts) completeFromGuidance(doc *gemara.GuidanceCatalog) {
+func (g *generateOpts) completeFromGuidance(doc gemara.GuidanceCatalog) {
 	if g.version == "" {
 		g.version = doc.Metadata.Version
 	}
@@ -21,7 +23,7 @@ func (g *generateOpts) completeFromGuidance(doc *gemara.GuidanceCatalog) {
 	}
 }
 
-func (g *generateOpts) completeFromCatalog(catalog *gemara.ControlCatalog) {
+func (g *generateOpts) completeFromCatalog(catalog gemara.ControlCatalog) {
 	if g.version == "" {
 		g.version = catalog.Metadata.Version
 	}

--- a/gemaraconv/options.go
+++ b/gemaraconv/options.go
@@ -139,3 +139,43 @@ func WithInlineLexicon(terms []InlineLexiconTerm) MarkdownOption {
 		o.inlineLexicon = terms
 	}
 }
+
+type evalOpts struct {
+	catalog      *gemara.ControlCatalog
+	importApHref string
+	artifactURI  string
+}
+
+func defaultEvalOpts() evalOpts {
+	return evalOpts{importApHref: "#"}
+}
+
+// EvalOption configures EvaluationLog conversions (SARIF, OSCAL Assessment Results).
+// Options irrelevant to a particular output format are ignored.
+type EvalOption func(*evalOpts)
+
+// WithImportApHref sets the URI referencing the governing assessment plan.
+// Used by OSCAL Assessment Results; defaults to "#" if unset.
+func WithImportApHref(href string) EvalOption {
+	return func(o *evalOpts) {
+		if href != "" {
+			o.importApHref = href
+		}
+	}
+}
+
+// WithCatalog provides a ControlCatalog to enrich output with control titles,
+// requirement text, and recommendations. Used by both SARIF and OSCAL Assessment Results.
+func WithCatalog(catalog *gemara.ControlCatalog) EvalOption {
+	return func(o *evalOpts) {
+		o.catalog = catalog
+	}
+}
+
+// WithArtifactURI sets the file path or URI for SARIF PhysicalLocation.
+// Used by SARIF conversion; defaults to a placeholder when empty.
+func WithArtifactURI(uri string) EvalOption {
+	return func(o *evalOpts) {
+		o.artifactURI = uri
+	}
+}

--- a/gemaraconv/sarif.go
+++ b/gemaraconv/sarif.go
@@ -13,18 +13,19 @@ var emptyArtifactURIMessage = "no file associated with this alert"
 // Each AssessmentLog is emitted as a SARIF result. The rule id is derived from
 // the control id and requirement id.
 //
-// Parameters:
-//   - evaluationLog: The evaluation log to convert
-//   - artifactURI: File path or URI for PhysicalLocation.artifactLocation.uri.
-//     If empty, PhysicalLocation will be nil (no resource URI available).
-//     For GitHub Code Scanning, typically use a file path like "README.md".
-//   - catalog: Optional catalog data to enrich SARIF output with requirement text
-//     and recommendations. If nil, only basic information is included.
+// Use WithArtifactURI to set PhysicalLocation (defaults to a placeholder).
+// Use WithCatalog to enrich rules with requirement text and recommendations.
 //
 // PhysicalLocation identifies the artifact (file/repository) where the result was found.
 // LogicalLocation identifies the logical component (assessment step) that produced the result.
 // Region is left nil as we don't have file-specific line/column data.
-func ToSARIF(evaluationLog gemara.EvaluationLog, artifactURI string, catalog *gemara.ControlCatalog) ([]byte, error) {
+func ToSARIF(evaluationLog gemara.EvaluationLog, opts ...EvalOption) ([]byte, error) {
+	options := defaultEvalOpts()
+	for _, opt := range opts {
+		opt(&options)
+	}
+	artifactURI := options.artifactURI
+	catalog := options.catalog
 	report := &SarifReport{
 		Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/123e95847b13fbdd4cbe2120fa5e33355d4a042b/Schemata/sarif-schema-2.1.0.json",
 		Version: "2.1.0",

--- a/gemaraconv/sarif_test.go
+++ b/gemaraconv/sarif_test.go
@@ -13,8 +13,7 @@ func TestFromEvaluationLog(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		artifactURI   string
-		catalog       *gemara.ControlCatalog
+		opts          []EvalOption
 		evaluationLog gemara.EvaluationLog
 		wantRules     int
 		wantResults   int
@@ -26,9 +25,8 @@ func TestFromEvaluationLog(t *testing.T) {
 		checkRule     func(*testing.T, *ReportingDescriptor)
 	}{
 		{
-			name:        "basic conversion with multiple results",
-			artifactURI: "",
-			catalog:     nil,
+			name: "basic conversion with multiple results",
+			opts: nil,
 			evaluationLog: makeEvaluationLog(gemara.Actor{
 				Name:    "gemara",
 				Uri:     "https://github.com/gemaraproj/go-gemara",
@@ -55,9 +53,8 @@ func TestFromEvaluationLog(t *testing.T) {
 			},
 		},
 		{
-			name:        "with artifactURI parameter",
-			artifactURI: "README.md",
-			catalog:     nil,
+			name: "with artifactURI parameter",
+			opts: []EvalOption{WithArtifactURI("README.md")},
 			evaluationLog: makeEvaluationLog(gemara.Actor{
 				Name:    "gemara",
 				Uri:     "https://github.com/test/repo",
@@ -80,9 +77,8 @@ func TestFromEvaluationLog(t *testing.T) {
 			},
 		},
 		{
-			name:        "empty author URI",
-			artifactURI: "",
-			catalog:     nil,
+			name: "empty author URI",
+			opts: nil,
 			evaluationLog: makeEvaluationLog(gemara.Actor{
 				Name:    "gemara",
 				Uri:     "",
@@ -105,9 +101,8 @@ func TestFromEvaluationLog(t *testing.T) {
 			},
 		},
 		{
-			name:        "with catalog enrichment",
-			artifactURI: "README.md",
-			catalog:     testCatalog,
+			name: "with catalog enrichment",
+			opts: []EvalOption{WithArtifactURI("README.md"), WithCatalog(testCatalog)},
 			evaluationLog: makeEvaluationLog(gemara.Actor{
 				Name:    "test-tool",
 				Uri:     "https://github.com/test/tool",
@@ -146,9 +141,8 @@ func TestFromEvaluationLog(t *testing.T) {
 			},
 		},
 		{
-			name:        "without catalog",
-			artifactURI: "README.md",
-			catalog:     nil,
+			name: "without catalog",
+			opts: []EvalOption{WithArtifactURI("README.md")},
 			evaluationLog: makeEvaluationLog(gemara.Actor{
 				Name:    "test-tool",
 				Uri:     "https://github.com/test/tool",
@@ -183,9 +177,8 @@ func TestFromEvaluationLog(t *testing.T) {
 			},
 		},
 		{
-			name:        "catalog recommendation when assessment log has none",
-			artifactURI: "README.md",
-			catalog:     testCatalog,
+			name: "catalog recommendation when assessment log has none",
+			opts: []EvalOption{WithArtifactURI("README.md"), WithCatalog(testCatalog)},
 			evaluationLog: makeEvaluationLog(gemara.Actor{
 				Name:    "test-tool",
 				Uri:     "https://github.com/test/tool",
@@ -219,7 +212,7 @@ func TestFromEvaluationLog(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sarifBytes, err := ToSARIF(tt.evaluationLog, tt.artifactURI, tt.catalog)
+			sarifBytes, err := ToSARIF(tt.evaluationLog, tt.opts...)
 			require.NoError(t, err)
 
 			sarif := toSARIFReport(t, sarifBytes)
@@ -281,7 +274,7 @@ func TestToSARIF_ResultLevels(t *testing.T) {
 				makeAssessmentLog("REQ-1", "test", tt.result, "", nil),
 			})
 
-			sarifBytes, err := ToSARIF(evaluationLog, "", nil)
+			sarifBytes, err := ToSARIF(evaluationLog)
 			require.NoError(t, err)
 
 			sarif := toSARIFReport(t, sarifBytes)

--- a/test-data/good-evaluation-log.yaml
+++ b/test-data/good-evaluation-log.yaml
@@ -1,0 +1,58 @@
+metadata:
+  id: pvtr-baseline-scan
+  type: EvaluationLog
+  gemara-version: v1.0.0
+  version: "1.0.0"
+  date: "2025-08-22T16:02:00Z"
+  description: Baseline scan of pvtr GitHub repository
+  author:
+    id: pvtr-github-repo
+    name: pvtr-github-repo
+    type: Software
+    version: "0.1.0"
+result: Failed
+target:
+  id: pvtr
+  name: pvtr
+  type: Software
+evaluations:
+  - name: Access Control - MFA
+    result: Passed
+    message: Two-factor authentication is configured as required by the parent organization
+    control:
+      reference-id: osps
+      entry-id: OSPS-AC-01
+    assessment-logs:
+      - requirement:
+          reference-id: osps
+          entry-id: OSPS-AC-01.01
+        description: Verify MFA is required for sensitive resources
+        result: Passed
+        message: Two-factor authentication is configured as required by the parent organization
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        steps-executed: 1
+        start: "2025-08-22T16:02:00Z"
+        end: "2025-08-22T16:02:00.000003708Z"
+  - name: Documentation - User Guides
+    result: Failed
+    message: User guide was NOT specified in Security Insights data
+    control:
+      reference-id: osps
+      entry-id: OSPS-DO-01
+    assessment-logs:
+      - requirement:
+          reference-id: osps
+          entry-id: OSPS-DO-01.01
+        description: Verify project documentation includes user guides for basic functionality
+        result: Failed
+        message: User guide was NOT specified in Security Insights data
+        recommendation: Add a user guide to the project documentation and reference it in Security Insights data
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        steps-executed: 3
+        start: "2025-08-22T16:02:00Z"


### PR DESCRIPTION
## Summary

  • Add EvaluationLogToOSCALAssessmentResults converter with functional options (WithImportApHref, WithCatalog) and evaluation CLI subcommand
  • Refactor gemaraconv API to accept value types and use functional options for all optional parameters

## Notes

- The first commit refactors the `gemaraconv` public API to remove pointer arguments that don't require in-function modification. This is a prerequisite for the converter commits that follow.
- Constraint validation is disabled for `assessment-results.json` because OSCAL's validator resolves the full document chain. Standalone assessment results without companion documents cannot satisfy this, but schema validation still runs. Related upstream issues: https://github.com/metaschema-framework/oscal-cli/issues/83


Addresses #29 partially