### PR TITLE
feat: add OCI bundle packaging, assembly, and artifact type detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,50 @@ func main() {
 }
 ```
 
+#### Bundling and Distributing Artifacts via OCI
+
+```go
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/gemaraproj/go-gemara/bundle"
+	"github.com/gemaraproj/go-gemara/fetcher"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/oci"
+	"oras.land/oras-go/v2/registry/remote"
+)
+
+func main() {
+	ctx := context.Background()
+	
+	data, _ := os.ReadFile("policy.yaml")
+	src := bundle.File{Name: "policy.yaml", Data: data}
+
+	// Assemble the full dependency tree (extends + imports)
+	m := bundle.Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"}
+	asm := bundle.NewAssembler(&fetcher.URI{})
+	b, _ := asm.Assemble(ctx, m, src)
+
+	// Pack into a local OCI layout
+	layoutStore, _ := oci.New("./bundle-output")
+	desc, _ := bundle.Pack(ctx, layoutStore, b)
+	_ = layoutStore.Tag(ctx, desc, "v1.0.0")
+
+	// Push to a remote OCI registry
+	repo, _ := remote.NewRepository("registry.example.com/org/bundle")
+	tagDesc, _ := layoutStore.Resolve(ctx, "v1.0.0")
+	_ = oras.CopyGraph(ctx, layoutStore, repo, tagDesc, oras.DefaultCopyGraphOptions)
+	_ = repo.Tag(ctx, tagDesc, "v1.0.0")
+
+	// Unpack from the registry
+	unpacked, _ := bundle.Unpack(ctx, repo, "v1.0.0")
+	_ = unpacked 
+}
+```
+
 #### Converting to SARIF
 
 ```go

--- a/bundle/assemble.go
+++ b/bundle/assemble.go
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package bundle
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"path"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/gemaraproj/go-gemara/internal/codec"
+)
+
+// Assembler walks the full import graph of Gemara artifacts and produces
+// a self-contained Bundle with all transitive dependencies fetched.
+type Assembler struct {
+	fetcher gemara.Fetcher
+}
+
+// NewAssembler creates an Assembler backed by the given Fetcher.
+func NewAssembler(f gemara.Fetcher) *Assembler {
+	return &Assembler{fetcher: f}
+}
+
+// parsedFile pairs a bundle File with its parsed outbound reference data.
+type parsedFile struct {
+	File
+	id      string
+	artType gemara.ArtifactType
+	refIDs  []string
+	refURLs map[string]string
+}
+
+// parseFile decodes a Gemara YAML file into either a gemara.Catalog
+// or gemara.Policy and extracts the identity and outbound reference
+// information needed for dependency resolution.
+func parseFile(f File) (*parsedFile, error) {
+	pf := &parsedFile{File: f}
+	artType, err := gemara.DetectType(f.Data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", f.Name, err)
+	}
+
+	switch artType {
+	case gemara.PolicyArtifact:
+		var pol gemara.Policy
+		if err := codec.UnmarshalYAML(f.Data, &pol); err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", f.Name, err)
+		}
+		pf.id = pol.Metadata.Id
+		pf.artType = pol.Metadata.Type
+		pf.refURLs = mappingRefURLs(pol.Metadata.MappingReferences)
+		pf.refIDs = policyRefIDs(pol.Imports)
+	default:
+		var cat gemara.Catalog
+		if err := codec.UnmarshalYAML(f.Data, &cat); err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", f.Name, err)
+		}
+		pf.id = cat.Metadata.Id
+		pf.artType = cat.Metadata.Type
+		pf.refURLs = mappingRefURLs(cat.Metadata.MappingReferences)
+		pf.refIDs = catalogRefIDs(cat.Extends, cat.Imports)
+	}
+
+	return pf, nil
+}
+
+// Assemble parses each source file, fetches every artifact referenced in
+// their extends and imports via mapping-references URLs, then
+// recursively parses fetched artifacts for their own references until the
+// full dependency tree is resolved.
+func (a *Assembler) Assemble(ctx context.Context, m Manifest, sources ...File) (*Bundle, error) {
+	if len(sources) == 0 {
+		return nil, fmt.Errorf("at least one source file is required")
+	}
+
+	seen := make(map[string]bool)
+	depMap := make(map[string][]string)
+
+	var sourceParsed []*parsedFile
+	var queue []fetchRef
+
+	for _, f := range sources {
+		pf, err := parseFile(f)
+		if err != nil {
+			return nil, err
+		}
+		sourceParsed = append(sourceParsed, pf)
+		queue = append(queue, enqueueRefs(pf, seen, depMap)...)
+	}
+
+	var importParsed []*parsedFile
+
+	for len(queue) > 0 {
+		item := queue[0]
+		queue = queue[1:]
+
+		if seen[item.url] {
+			continue
+		}
+		seen[item.url] = true
+
+		data, err := a.fetchAll(ctx, item.url)
+		if err != nil {
+			return nil, fmt.Errorf("fetching dependency %q from %s: %w", item.refID, item.url, err)
+		}
+
+		f := File{
+			Name: importFileName(item.refID, item.url),
+			Data: data,
+		}
+
+		pf, err := parseFile(f)
+		if err != nil {
+			return nil, fmt.Errorf("parsing transitive refs from %s: %w", f.Name, err)
+		}
+		importParsed = append(importParsed, pf)
+		queue = append(queue, enqueueRefs(pf, seen, depMap)...)
+	}
+
+	files := make([]File, len(sources))
+	copy(files, sources)
+
+	var imports []File
+	for _, pf := range importParsed {
+		imports = append(imports, pf.File)
+	}
+
+	m.Artifacts = buildArtifactTree(sourceParsed, importParsed, depMap)
+
+	return &Bundle{
+		Manifest: m,
+		Files:    files,
+		Imports:  imports,
+	}, nil
+}
+
+// fetchRef is a URL-keyed reference waiting to be fetched.
+type fetchRef struct {
+	refID string
+	url   string
+}
+
+// enqueueRefs builds fetchRef items for each outbound reference that
+// has a resolvable URL and hasn't been seen yet. It also records
+// dependency edges in depMap.
+func enqueueRefs(pf *parsedFile, seen map[string]bool, depMap map[string][]string) []fetchRef {
+	var refs []fetchRef
+	for _, refID := range pf.refIDs {
+		fetchURL, ok := pf.refURLs[refID]
+		if !ok {
+			continue
+		}
+
+		depName := importFileName(refID, fetchURL)
+		depMap[pf.Name] = append(depMap[pf.Name], depName)
+
+		if seen[fetchURL] {
+			continue
+		}
+		refs = append(refs, fetchRef{refID: refID, url: fetchURL})
+	}
+	return refs
+}
+
+// mappingRefURLs builds an id -> url lookup from MappingReferences.
+func mappingRefURLs(refs []gemara.MappingReference) map[string]string {
+	m := make(map[string]string, len(refs))
+	for _, ref := range refs {
+		if ref.Url != "" {
+			m[ref.Id] = ref.Url
+		}
+	}
+	return m
+}
+
+// catalogRefIDs collects all reference IDs from extends and catalog-style imports.
+func catalogRefIDs(extends []gemara.ArtifactMapping, imports []gemara.MultiEntryMapping) []string {
+	var ids []string
+	for _, ext := range extends {
+		if ext.ReferenceId != "" {
+			ids = append(ids, ext.ReferenceId)
+		}
+	}
+	for _, imp := range imports {
+		if imp.ReferenceId != "" {
+			ids = append(ids, imp.ReferenceId)
+		}
+	}
+	return ids
+}
+
+// policyRefIDs collects all reference IDs from a Policy's typed imports.
+func policyRefIDs(imports gemara.Imports) []string {
+	var ids []string
+	for _, p := range imports.Policies {
+		if p.ReferenceId != "" {
+			ids = append(ids, p.ReferenceId)
+		}
+	}
+	for _, c := range imports.Catalogs {
+		if c.ReferenceId != "" {
+			ids = append(ids, c.ReferenceId)
+		}
+	}
+	for _, g := range imports.Guidance {
+		if g.ReferenceId != "" {
+			ids = append(ids, g.ReferenceId)
+		}
+	}
+	return ids
+}
+
+// buildArtifactTree constructs the Manifest.Artifacts slice from the
+// already-parsed files and their dependency relationships.
+func buildArtifactTree(files, imports []*parsedFile, depMap map[string][]string) []Artifact {
+	artifacts := make([]Artifact, 0, len(files)+len(imports))
+	for _, pf := range files {
+		artifacts = append(artifacts, Artifact{
+			Name:         pf.Name,
+			Type:         pf.artType.String(),
+			ID:           pf.id,
+			Role:         roleArtifact,
+			Dependencies: depMap[pf.Name],
+		})
+	}
+	for _, pf := range imports {
+		artifacts = append(artifacts, Artifact{
+			Name:         pf.Name,
+			Type:         pf.artType.String(),
+			ID:           pf.id,
+			Role:         roleImport,
+			Dependencies: depMap[pf.Name],
+		})
+	}
+	return artifacts
+}
+
+func (a *Assembler) fetchAll(ctx context.Context, source string) ([]byte, error) {
+	rc, err := a.fetcher.Fetch(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close() //nolint:errcheck
+	return io.ReadAll(rc)
+}
+
+// importFileName derives a bundle-relative filename for a resolved import.
+func importFileName(refID, rawURL string) string {
+	if u, err := url.Parse(rawURL); err == nil {
+		if base := path.Base(u.Path); base != "" && base != "." && base != "/" {
+			return base
+		}
+	}
+	return refID + ".yaml"
+}

--- a/bundle/assemble_test.go
+++ b/bundle/assemble_test.go
@@ -1,0 +1,448 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package bundle
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mapFetcher is a test double that serves content from a static map.
+type mapFetcher map[string][]byte
+
+func (m mapFetcher) Fetch(_ context.Context, source string) (io.ReadCloser, error) {
+	data, ok := m[source]
+	if !ok {
+		return nil, fmt.Errorf("not found: %s", source)
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := yaml.Marshal(v)
+	require.NoError(t, err)
+	return data
+}
+
+var testAuthor = gemara.Actor{
+	Id:   "test-author",
+	Name: "Test Author",
+	Type: gemara.Human,
+}
+
+func testControlCatalog(id string, refs []gemara.MappingReference, extends []gemara.ArtifactMapping, imports []gemara.MultiEntryMapping) gemara.Catalog {
+	return gemara.Catalog{
+		Title: "Test Catalog",
+		Metadata: gemara.Metadata{
+			Id:                id,
+			Type:              gemara.ControlCatalogArtifact,
+			GemaraVersion:     "1.0.0",
+			Description:       "test catalog",
+			Author:            testAuthor,
+			MappingReferences: refs,
+		},
+		Extends: extends,
+		Imports: imports,
+	}
+}
+
+func testGuidanceCatalog(id string) gemara.GuidanceCatalog {
+	return gemara.GuidanceCatalog{
+		Title: "External Guidance",
+		Metadata: gemara.Metadata{
+			Id:            id,
+			Type:          gemara.GuidanceCatalogArtifact,
+			GemaraVersion: "1.0.0",
+			Description:   "imported guidance",
+			Author:        testAuthor,
+		},
+	}
+}
+
+func TestAssembler_Assemble(t *testing.T) {
+	guidance := testGuidanceCatalog("ext-guidance")
+
+	tests := []struct {
+		name    string
+		fetcher mapFetcher
+		sources []File
+		wantErr string
+		check   func(t *testing.T, b *Bundle)
+	}{
+		{
+			name: "resolves imports with manifest artifacts",
+			fetcher: mapFetcher{
+				"https://example.com/guidance.yaml": mustMarshal(t, guidance),
+			},
+			sources: []File{
+				{
+					Name: "controls.yaml",
+					Data: mustMarshal(t, testControlCatalog("test-cat",
+						[]gemara.MappingReference{
+							{Id: "EXT-GUIDE", Title: "External Guidance", Version: "1.0", Url: "https://example.com/guidance.yaml"},
+							{Id: "LOCAL-REF", Title: "Local Only", Version: "1.0"},
+						},
+						nil,
+						[]gemara.MultiEntryMapping{
+							{ReferenceId: "EXT-GUIDE", Entries: []gemara.ArtifactMapping{{ReferenceId: "G1"}}},
+						},
+					)),
+				},
+			},
+			check: func(t *testing.T, b *Bundle) {
+				assert.Equal(t, "1", b.Manifest.BundleVersion)
+				assert.Equal(t, "v1.0.0", b.Manifest.GemaraVersion)
+				require.Len(t, b.Files, 1)
+				assert.Equal(t, "controls.yaml", b.Files[0].Name)
+				require.Len(t, b.Imports, 1)
+				assert.Equal(t, "guidance.yaml", b.Imports[0].Name)
+
+				require.Len(t, b.Manifest.Artifacts, 2)
+				assert.Equal(t, Artifact{Name: "controls.yaml", Type: "ControlCatalog", ID: "test-cat", Role: roleArtifact, Dependencies: []string{"guidance.yaml"}}, b.Manifest.Artifacts[0])
+				assert.Equal(t, Artifact{Name: "guidance.yaml", Type: "GuidanceCatalog", ID: "ext-guidance", Role: roleImport}, b.Manifest.Artifacts[1])
+			},
+		},
+		{
+			name:    "skips mapping ref without URL",
+			fetcher: mapFetcher{},
+			sources: []File{
+				{
+					Name: "a.yaml",
+					Data: mustMarshal(t, testControlCatalog("test-cat",
+						[]gemara.MappingReference{{Id: "NO-URL", Title: "No URL", Version: "1.0"}},
+						nil,
+						[]gemara.MultiEntryMapping{
+							{ReferenceId: "NO-URL", Entries: []gemara.ArtifactMapping{{ReferenceId: "x"}}},
+						},
+					)),
+				},
+			},
+			check: func(t *testing.T, b *Bundle) {
+				assert.Nil(t, b.Imports)
+			},
+		},
+		{
+			name: "deduplicates shared dependency across sources",
+			fetcher: mapFetcher{
+				"https://example.com/shared.yaml": mustMarshal(t, testControlCatalog("shared", nil, nil, nil)),
+			},
+			sources: func() []File {
+				data := mustMarshal(t, testControlCatalog("test-cat",
+					[]gemara.MappingReference{{Id: "SHARED", Title: "Shared", Version: "1.0", Url: "https://example.com/shared.yaml"}},
+					nil,
+					[]gemara.MultiEntryMapping{
+						{ReferenceId: "SHARED", Entries: []gemara.ArtifactMapping{{ReferenceId: "x"}}},
+					},
+				))
+				return []File{{Name: "a.yaml", Data: data}, {Name: "b.yaml", Data: data}}
+			}(),
+			check: func(t *testing.T, b *Bundle) {
+				require.Len(t, b.Imports, 1, "duplicate import should be fetched once")
+				assert.Equal(t, "shared.yaml", b.Imports[0].Name)
+			},
+		},
+		{
+			name: "resolves extends references",
+			fetcher: mapFetcher{
+				"https://example.com/base.yaml": mustMarshal(t, testControlCatalog("base", nil, nil, nil)),
+			},
+			sources: []File{
+				{
+					Name: "child.yaml",
+					Data: mustMarshal(t, testControlCatalog("child",
+						[]gemara.MappingReference{{Id: "BASE", Title: "Base Catalog", Version: "1.0", Url: "https://example.com/base.yaml"}},
+						[]gemara.ArtifactMapping{{ReferenceId: "BASE", Remarks: "builds upon base"}},
+						nil,
+					)),
+				},
+			},
+			check: func(t *testing.T, b *Bundle) {
+				require.Len(t, b.Imports, 1)
+				assert.Equal(t, "base.yaml", b.Imports[0].Name)
+			},
+		},
+		{
+			name: "resolves both extends and imports",
+			fetcher: mapFetcher{
+				"https://example.com/base.yaml":  mustMarshal(t, testControlCatalog("base", nil, nil, nil)),
+				"https://example.com/guide.yaml": mustMarshal(t, testGuidanceCatalog("guide")),
+			},
+			sources: []File{
+				{
+					Name: "c.yaml",
+					Data: mustMarshal(t, testControlCatalog("combined",
+						[]gemara.MappingReference{
+							{Id: "BASE", Title: "Base", Version: "1.0", Url: "https://example.com/base.yaml"},
+							{Id: "GUIDE", Title: "Guide", Version: "1.0", Url: "https://example.com/guide.yaml"},
+						},
+						[]gemara.ArtifactMapping{{ReferenceId: "BASE"}},
+						[]gemara.MultiEntryMapping{
+							{ReferenceId: "GUIDE", Entries: []gemara.ArtifactMapping{{ReferenceId: "G1"}}},
+						},
+					)),
+				},
+			},
+			check: func(t *testing.T, b *Bundle) {
+				require.Len(t, b.Imports, 2)
+				names := importNames(b)
+				assert.True(t, names["base.yaml"], "extends dependency should be assembled")
+				assert.True(t, names["guide.yaml"], "import dependency should be assembled")
+			},
+		},
+		{
+			name: "policy imports catalogs and guidance",
+			fetcher: mapFetcher{
+				"https://example.com/controls.yaml": mustMarshal(t, testControlCatalog("ctrl", nil, nil, nil)),
+				"https://example.com/guidance.yaml": mustMarshal(t, testGuidanceCatalog("guide")),
+			},
+			sources: []File{
+				{
+					Name: "policy.yaml",
+					Data: mustMarshal(t, gemara.Policy{
+						Title: "Org Policy",
+						Metadata: gemara.Metadata{
+							Id: "org-policy", Type: gemara.PolicyArtifact, GemaraVersion: "1.0.0",
+							Description: "org-wide policy", Author: testAuthor,
+							MappingReferences: []gemara.MappingReference{
+								{Id: "CTRL", Title: "Control Catalog", Version: "1.0", Url: "https://example.com/controls.yaml"},
+								{Id: "GUIDE", Title: "Guidance Doc", Version: "1.0", Url: "https://example.com/guidance.yaml"},
+							},
+						},
+						Contacts: gemara.RACI{
+							Responsible: []gemara.Contact{{Name: "R"}},
+							Accountable: []gemara.Contact{{Name: "A"}},
+						},
+						Scope: gemara.Scope{In: gemara.Dimensions{Technologies: []string{"cloud"}}},
+						Imports: gemara.Imports{
+							Catalogs: []gemara.CatalogImport{{ReferenceId: "CTRL"}},
+							Guidance: []gemara.GuidanceImport{{ReferenceId: "GUIDE"}},
+						},
+						Adherence: gemara.Adherence{
+							EvaluationMethods: []gemara.AcceptedMethod{
+								{Id: "em1", Type: gemara.MethodGate, Mode: gemara.ModeAutomated, Required: true},
+							},
+						},
+					}),
+				},
+			},
+			check: func(t *testing.T, b *Bundle) {
+				require.Len(t, b.Imports, 2)
+				names := importNames(b)
+				assert.True(t, names["controls.yaml"])
+				assert.True(t, names["guidance.yaml"])
+			},
+		},
+		{
+			name:    "no imports produces single artifact",
+			fetcher: mapFetcher{},
+			sources: []File{
+				{Name: "e.yaml", Data: mustMarshal(t, testControlCatalog("e", nil, nil, nil))},
+			},
+			check: func(t *testing.T, b *Bundle) {
+				assert.Nil(t, b.Imports)
+				require.Len(t, b.Files, 1)
+				require.Len(t, b.Manifest.Artifacts, 1)
+				assert.Equal(t, roleArtifact, b.Manifest.Artifacts[0].Role)
+				assert.Nil(t, b.Manifest.Artifacts[0].Dependencies)
+			},
+		},
+		{
+			name:    "no sources returns error",
+			fetcher: mapFetcher{},
+			sources: nil,
+			wantErr: "at least one source",
+		},
+		{
+			name:    "fetch failure propagates error",
+			fetcher: mapFetcher{},
+			sources: []File{
+				{
+					Name: "c.yaml",
+					Data: mustMarshal(t, testControlCatalog("test-cat",
+						[]gemara.MappingReference{{Id: "EXT-GUIDE", Title: "External Guidance", Version: "1.0", Url: "https://example.com/guidance.yaml"}},
+						nil,
+						[]gemara.MultiEntryMapping{
+							{ReferenceId: "EXT-GUIDE", Entries: []gemara.ArtifactMapping{{ReferenceId: "G1"}}},
+						},
+					)),
+				},
+			},
+			wantErr: "fetching dependency",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asm := NewAssembler(tt.fetcher)
+			m := Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"}
+
+			b, err := asm.Assemble(context.Background(), m, tt.sources...)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			tt.check(t, b)
+		})
+	}
+}
+
+func TestAssembler_Assemble_TransitiveDeps(t *testing.T) {
+	tests := []struct {
+		name    string
+		fetcher mapFetcher
+		source  File
+		check   func(t *testing.T, b *Bundle)
+	}{
+		{
+			name: "resolves chain A -> B -> C",
+			fetcher: mapFetcher{
+				"https://example.com/catalog-b.yaml": mustMarshal(t, testControlCatalog("cat-b",
+					[]gemara.MappingReference{{Id: "CAT-C", Title: "Catalog C", Version: "1.0", Url: "https://example.com/catalog-c.yaml"}},
+					nil,
+					[]gemara.MultiEntryMapping{{ReferenceId: "CAT-C", Entries: []gemara.ArtifactMapping{{ReferenceId: "x"}}}},
+				)),
+				"https://example.com/catalog-c.yaml": mustMarshal(t, testControlCatalog("cat-c", nil, nil, nil)),
+			},
+			source: File{
+				Name: "catalog-a.yaml",
+				Data: mustMarshal(t, testControlCatalog("cat-a",
+					[]gemara.MappingReference{{Id: "CAT-B", Title: "Catalog B", Version: "1.0", Url: "https://example.com/catalog-b.yaml"}},
+					nil,
+					[]gemara.MultiEntryMapping{{ReferenceId: "CAT-B", Entries: []gemara.ArtifactMapping{{ReferenceId: "y"}}}},
+				)),
+			},
+			check: func(t *testing.T, b *Bundle) {
+				require.Len(t, b.Files, 1)
+				assert.Equal(t, "catalog-a.yaml", b.Files[0].Name)
+				require.Len(t, b.Imports, 2, "both B and C should be assembled transitively")
+				names := importNames(b)
+				assert.True(t, names["catalog-b.yaml"], "direct dependency B")
+				assert.True(t, names["catalog-c.yaml"], "transitive dependency C")
+
+				artByName := artifactsByName(b)
+				assert.Equal(t, []string{"catalog-b.yaml"}, artByName["catalog-a.yaml"].Dependencies)
+				assert.Equal(t, []string{"catalog-c.yaml"}, artByName["catalog-b.yaml"].Dependencies)
+				assert.Nil(t, artByName["catalog-c.yaml"].Dependencies)
+			},
+		},
+		{
+			name: "terminates on cycle A <-> B",
+			fetcher: mapFetcher{
+				"https://example.com/catalog-a.yaml": mustMarshal(t, testControlCatalog("cat-a",
+					[]gemara.MappingReference{{Id: "CAT-B", Title: "Catalog B", Version: "1.0", Url: "https://example.com/catalog-b.yaml"}},
+					nil,
+					[]gemara.MultiEntryMapping{{ReferenceId: "CAT-B", Entries: []gemara.ArtifactMapping{{ReferenceId: "y"}}}},
+				)),
+				"https://example.com/catalog-b.yaml": mustMarshal(t, testControlCatalog("cat-b",
+					[]gemara.MappingReference{{Id: "CAT-A", Title: "Catalog A", Version: "1.0", Url: "https://example.com/catalog-a.yaml"}},
+					nil,
+					[]gemara.MultiEntryMapping{{ReferenceId: "CAT-A", Entries: []gemara.ArtifactMapping{{ReferenceId: "x"}}}},
+				)),
+			},
+			source: File{
+				Name: "catalog-a.yaml",
+				Data: mustMarshal(t, testControlCatalog("cat-a",
+					[]gemara.MappingReference{{Id: "CAT-B", Title: "Catalog B", Version: "1.0", Url: "https://example.com/catalog-b.yaml"}},
+					nil,
+					[]gemara.MultiEntryMapping{{ReferenceId: "CAT-B", Entries: []gemara.ArtifactMapping{{ReferenceId: "y"}}}},
+				)),
+			},
+			check: func(t *testing.T, b *Bundle) {
+				require.Len(t, b.Imports, 2, "terminates despite cycle")
+				names := importNames(b)
+				assert.True(t, names["catalog-b.yaml"])
+				assert.True(t, names["catalog-a.yaml"])
+			},
+		},
+		{
+			name: "diamond dependency deduplicates shared leaf",
+			fetcher: mapFetcher{
+				"https://example.com/catalog-b.yaml": mustMarshal(t, testControlCatalog("cat-b",
+					[]gemara.MappingReference{{Id: "CAT-D", Title: "Catalog D", Version: "1.0", Url: "https://example.com/catalog-d.yaml"}},
+					nil,
+					[]gemara.MultiEntryMapping{{ReferenceId: "CAT-D", Entries: []gemara.ArtifactMapping{{ReferenceId: "x"}}}},
+				)),
+				"https://example.com/catalog-c.yaml": mustMarshal(t, testControlCatalog("cat-c",
+					[]gemara.MappingReference{{Id: "CAT-D", Title: "Catalog D", Version: "1.0", Url: "https://example.com/catalog-d.yaml"}},
+					nil,
+					[]gemara.MultiEntryMapping{{ReferenceId: "CAT-D", Entries: []gemara.ArtifactMapping{{ReferenceId: "y"}}}},
+				)),
+				"https://example.com/catalog-d.yaml": mustMarshal(t, testControlCatalog("cat-d", nil, nil, nil)),
+			},
+			source: File{
+				Name: "catalog-a.yaml",
+				Data: mustMarshal(t, testControlCatalog("cat-a",
+					[]gemara.MappingReference{
+						{Id: "CAT-B", Title: "Catalog B", Version: "1.0", Url: "https://example.com/catalog-b.yaml"},
+						{Id: "CAT-C", Title: "Catalog C", Version: "1.0", Url: "https://example.com/catalog-c.yaml"},
+					},
+					nil,
+					[]gemara.MultiEntryMapping{
+						{ReferenceId: "CAT-B", Entries: []gemara.ArtifactMapping{{ReferenceId: "x"}}},
+						{ReferenceId: "CAT-C", Entries: []gemara.ArtifactMapping{{ReferenceId: "y"}}},
+					},
+				)),
+			},
+			check: func(t *testing.T, b *Bundle) {
+				require.Len(t, b.Imports, 3, "B, C, D all assembled; D only once")
+				names := importNames(b)
+				assert.True(t, names["catalog-b.yaml"])
+				assert.True(t, names["catalog-c.yaml"])
+				assert.True(t, names["catalog-d.yaml"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asm := NewAssembler(tt.fetcher)
+			b, err := asm.Assemble(context.Background(), Manifest{}, tt.source)
+			require.NoError(t, err)
+			tt.check(t, b)
+		})
+	}
+}
+
+func TestImportFileName(t *testing.T) {
+	tests := []struct {
+		refID string
+		url   string
+		want  string
+	}{
+		{"EXT", "https://example.com/guidance.yaml", "guidance.yaml"},
+		{"EXT", "https://example.com/", "EXT.yaml"},
+		{"EXT", "not a url ://", "EXT.yaml"},
+		{"MY-REF", "file:///tmp/data.yaml", "data.yaml"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.refID+"_"+tt.url, func(t *testing.T) {
+			assert.Equal(t, tt.want, importFileName(tt.refID, tt.url))
+		})
+	}
+}
+
+func importNames(b *Bundle) map[string]bool {
+	names := make(map[string]bool, len(b.Imports))
+	for _, imp := range b.Imports {
+		names[imp.Name] = true
+	}
+	return names
+}
+
+func artifactsByName(b *Bundle) map[string]Artifact {
+	m := make(map[string]Artifact, len(b.Manifest.Artifacts))
+	for _, a := range b.Manifest.Artifacts {
+		m[a.Name] = a
+	}
+	return m
+}

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package bundle defines the Gemara OCI artifact format and provides
+// Assemble, Pack, and Unpack operations for building, storing, and
+// retrieving Gemara artifacts in OCI-compliant registries.
+package bundle
+
+const (
+	// DefaultSizeLimitBytes caps bundle reads at 256 MB.
+	DefaultSizeLimitBytes int64 = 256 * 1024 * 1024
+)
+
+// OCI media types for the Gemara bundle format.
+// All artifact layers are YAML; the assembler and resolver expect YAML input.
+const (
+	// MediaTypeBundle is the OCI artifactType written into the image manifest.
+	MediaTypeBundle = "application/vnd.gemara.bundle.v1"
+
+	// MediaTypeManifest is the media type for the bundle manifest blob.
+	MediaTypeManifest = "application/vnd.gemara.manifest.v1+json"
+
+	// MediaTypeArtifact is the media type for individual Gemara YAML layers.
+	MediaTypeArtifact = "application/vnd.gemara.artifact.v1+yaml"
+)
+
+// Internal annotation used to distinguish primary artifacts from imports.
+const (
+	annotationRole = "org.gemara.artifact.role"
+	roleArtifact   = "artifact"
+	roleImport     = "import"
+)
+
+// Manifest defines the OCI config blob stored in the bundle.
+type Manifest struct {
+	BundleVersion string         `json:"bundle-version"`
+	GemaraVersion string         `json:"gemara-version"`
+	Revision      string         `json:"revision,omitempty"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
+	Artifacts     []Artifact     `json:"artifacts,omitempty"`
+}
+
+// Empty reports whether the manifest carries no meaningful data.
+func (m Manifest) Empty() bool {
+	return m.BundleVersion == "" && m.GemaraVersion == "" &&
+		m.Revision == "" && len(m.Metadata) == 0 &&
+		len(m.Artifacts) == 0
+}
+
+// Artifact describes a single file in the bundle and its position
+// in the dependency tree, similar to rootfs in an OCI image config.
+type Artifact struct {
+	Name         string   `json:"name"`
+	Type         string   `json:"type"`
+	ID           string   `json:"id"`
+	Role         string   `json:"role"`
+	Dependencies []string `json:"dependencies,omitempty"`
+}
+
+// File is a single Gemara YAML artifact within the bundle.
+type File struct {
+	// Name is the bundle-relative path, e.g. "controls.yaml".
+	Name string
+	// Data is the raw YAML content of the artifact.
+	Data []byte
+}
+
+// Bundle is an in-memory representation of a Gemara OCI artifact.
+type Bundle struct {
+	// Manifest is the OCI config blob describing the bundle contents.
+	Manifest Manifest
+	// Files are the primary artifact files provided as assembly sources.
+	Files []File
+	// Imports are the resolved transitive dependency files.
+	Imports []File
+	// Etag is the OCI manifest digest used for cache comparison.
+	Etag string
+
+	sizeLimitBytes int64
+}
+
+// SizeLimitBytes returns the configured size limit.
+// If unset, DefaultSizeLimitBytes is returned.
+func (b *Bundle) SizeLimitBytes() int64 {
+	if b.sizeLimitBytes > 0 {
+		return b.sizeLimitBytes
+	}
+	return DefaultSizeLimitBytes
+}
+
+// SetSizeLimitBytes configures the maximum allowed bundle size.
+func (b *Bundle) SetSizeLimitBytes(n int64) {
+	b.sizeLimitBytes = n
+}
+
+// PackOption configures Pack behaviour.
+type PackOption func(*packOptions)
+
+type packOptions struct {
+	annotations map[string]string
+}
+
+// WithAnnotations adds custom annotations to the OCI manifest.
+func WithAnnotations(annotations map[string]string) PackOption {
+	return func(o *packOptions) {
+		o.annotations = annotations
+	}
+}

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -23,9 +23,10 @@ const (
 	MediaTypeArtifact = "application/vnd.gemara.artifact.v1+yaml"
 )
 
-// Internal annotation used to distinguish primary artifacts from imports.
+// Internal annotations carried on layer descriptors.
 const (
 	annotationRole = "org.gemara.artifact.role"
+	annotationType = "org.gemara.artifact.type"
 	roleArtifact   = "artifact"
 	roleImport     = "import"
 )
@@ -60,6 +61,8 @@ type Artifact struct {
 type File struct {
 	// Name is the bundle-relative path, e.g. "controls.yaml".
 	Name string
+	// Type is the Gemara artifact type, e.g. "ControlCatalog".
+	Type string
 	// Data is the raw YAML content of the artifact.
 	Data []byte
 }

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package bundle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/content/memory"
+)
+
+func TestPackUnpack(t *testing.T) {
+	tests := []struct {
+		name    string
+		bundle  *Bundle
+		tag     string
+		opts    []PackOption
+		wantErr string
+		check   func(t *testing.T, original *Bundle, got *Bundle)
+	}{
+		{
+			name: "round trip preserves files and imports",
+			bundle: &Bundle{
+				Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
+				Files: []File{
+					{Name: "controls.yaml", Data: []byte("id: ctrl-catalog\ncontrols: []")},
+				},
+				Imports: []File{
+					{Name: "imported-guidance.yaml", Data: []byte("id: guidance-import\nguidelines: []")},
+				},
+			},
+			tag: "v1.0.0",
+			check: func(t *testing.T, original *Bundle, got *Bundle) {
+				assert.Equal(t, original.Manifest, got.Manifest)
+				assert.NotEmpty(t, got.Etag)
+				require.Len(t, got.Files, 1)
+				assert.Equal(t, "controls.yaml", got.Files[0].Name)
+				assert.Equal(t, original.Files[0].Data, got.Files[0].Data)
+				require.Len(t, got.Imports, 1)
+				assert.Equal(t, "imported-guidance.yaml", got.Imports[0].Name)
+				assert.Equal(t, original.Imports[0].Data, got.Imports[0].Data)
+			},
+		},
+		{
+			name: "multiple files without imports",
+			bundle: &Bundle{
+				Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
+				Files: []File{
+					{Name: "controls.yaml", Data: []byte("controls: [one]")},
+					{Name: "threats.yaml", Data: []byte("threats: [two]")},
+				},
+			},
+			tag: "latest",
+			check: func(t *testing.T, original *Bundle, got *Bundle) {
+				assert.Equal(t, original.Manifest, got.Manifest)
+				require.Len(t, got.Files, 2)
+				assert.Nil(t, got.Imports)
+			},
+		},
+		{
+			name: "custom annotations propagated",
+			bundle: &Bundle{
+				Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
+				Files:    []File{{Name: "c.yaml", Data: []byte("data")}},
+			},
+			tag:  "annotated",
+			opts: []PackOption{WithAnnotations(map[string]string{"org.example.source": "ci"})},
+			check: func(t *testing.T, _ *Bundle, got *Bundle) {
+				require.Len(t, got.Files, 1)
+			},
+		},
+		{
+			name: "duplicate content across files and imports",
+			bundle: &Bundle{
+				Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
+				Files:    []File{{Name: "a.yaml", Data: []byte("identical content")}},
+				Imports:  []File{{Name: "b.yaml", Data: []byte("identical content")}},
+			},
+			tag: "dup",
+			check: func(t *testing.T, _ *Bundle, got *Bundle) {
+				require.Len(t, got.Files, 1)
+				require.Len(t, got.Imports, 1)
+				assert.Equal(t, "a.yaml", got.Files[0].Name)
+				assert.Equal(t, "b.yaml", got.Imports[0].Name)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := memory.New()
+
+			desc, err := Pack(ctx, store, tt.bundle, tt.opts...)
+			require.NoError(t, err)
+			require.NotEmpty(t, desc.Digest)
+			require.NoError(t, store.Tag(ctx, desc, tt.tag))
+
+			got, err := Unpack(ctx, store, tt.tag)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			tt.check(t, tt.bundle, got)
+		})
+	}
+}
+
+func TestPackUnpack_Annotations(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+
+	b := &Bundle{
+		Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
+		Files:    []File{{Name: "c.yaml", Data: []byte("data")}},
+	}
+	desc, err := Pack(ctx, store, b, WithAnnotations(map[string]string{
+		"org.example.source": "ci",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, "ci", desc.Annotations["org.example.source"])
+}
+
+func TestPack_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		bundle  *Bundle
+		wantErr string
+	}{
+		{
+			name:    "nil bundle",
+			bundle:  nil,
+			wantErr: "bundle must not be nil",
+		},
+		{
+			name:    "empty files",
+			bundle:  &Bundle{},
+			wantErr: "at least one artifact file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Pack(context.Background(), memory.New(), tt.bundle)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestUnpack_BadRef(t *testing.T) {
+	_, err := Unpack(context.Background(), memory.New(), "does-not-exist")
+	assert.Error(t, err)
+}

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -25,10 +25,10 @@ func TestPackUnpack(t *testing.T) {
 			bundle: &Bundle{
 				Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
 				Files: []File{
-					{Name: "controls.yaml", Data: []byte("id: ctrl-catalog\ncontrols: []")},
+					{Name: "controls.yaml", Type: "ControlCatalog", Data: []byte("id: ctrl-catalog\ncontrols: []")},
 				},
 				Imports: []File{
-					{Name: "imported-guidance.yaml", Data: []byte("id: guidance-import\nguidelines: []")},
+					{Name: "imported-guidance.yaml", Type: "GuidanceCatalog", Data: []byte("id: guidance-import\nguidelines: []")},
 				},
 			},
 			tag: "v1.0.0",
@@ -37,9 +37,11 @@ func TestPackUnpack(t *testing.T) {
 				assert.NotEmpty(t, got.Etag)
 				require.Len(t, got.Files, 1)
 				assert.Equal(t, "controls.yaml", got.Files[0].Name)
+				assert.Equal(t, "ControlCatalog", got.Files[0].Type)
 				assert.Equal(t, original.Files[0].Data, got.Files[0].Data)
 				require.Len(t, got.Imports, 1)
 				assert.Equal(t, "imported-guidance.yaml", got.Imports[0].Name)
+				assert.Equal(t, "GuidanceCatalog", got.Imports[0].Type)
 				assert.Equal(t, original.Imports[0].Data, got.Imports[0].Data)
 			},
 		},
@@ -48,14 +50,16 @@ func TestPackUnpack(t *testing.T) {
 			bundle: &Bundle{
 				Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
 				Files: []File{
-					{Name: "controls.yaml", Data: []byte("controls: [one]")},
-					{Name: "threats.yaml", Data: []byte("threats: [two]")},
+					{Name: "controls.yaml", Type: "ControlCatalog", Data: []byte("controls: [one]")},
+					{Name: "threats.yaml", Type: "ThreatCatalog", Data: []byte("threats: [two]")},
 				},
 			},
 			tag: "latest",
 			check: func(t *testing.T, original *Bundle, got *Bundle) {
 				assert.Equal(t, original.Manifest, got.Manifest)
 				require.Len(t, got.Files, 2)
+				assert.Equal(t, "ControlCatalog", got.Files[0].Type)
+				assert.Equal(t, "ThreatCatalog", got.Files[1].Type)
 				assert.Nil(t, got.Imports)
 			},
 		},
@@ -84,6 +88,18 @@ func TestPackUnpack(t *testing.T) {
 				require.Len(t, got.Imports, 1)
 				assert.Equal(t, "a.yaml", got.Files[0].Name)
 				assert.Equal(t, "b.yaml", got.Imports[0].Name)
+			},
+		},
+		{
+			name: "omitted type round-trips as empty string",
+			bundle: &Bundle{
+				Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
+				Files:    []File{{Name: "plain.yaml", Data: []byte("data")}},
+			},
+			tag: "no-type",
+			check: func(t *testing.T, _ *Bundle, got *Bundle) {
+				require.Len(t, got.Files, 1)
+				assert.Empty(t, got.Files[0].Type)
 			},
 		},
 	}

--- a/bundle/pack.go
+++ b/bundle/pack.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package bundle
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/errdef"
+)
+
+// Pack writes the Bundle as OCI layers into target and returns the
+// manifest descriptor. The caller is responsible for tagging or copying
+// the result to a registry.
+func Pack(ctx context.Context, target oras.Target, b *Bundle, opts ...PackOption) (ocispec.Descriptor, error) {
+	if b == nil {
+		return ocispec.Descriptor{}, fmt.Errorf("bundle must not be nil")
+	}
+	if len(b.Files) == 0 {
+		return ocispec.Descriptor{}, fmt.Errorf("bundle must contain at least one artifact file")
+	}
+
+	o := &packOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	manifestData, err := json.Marshal(b.Manifest)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("marshaling manifest: %w", err)
+	}
+	manifestDesc := descFromBytes(MediaTypeManifest, manifestData)
+	if err := pushBlob(ctx, target, manifestDesc, manifestData); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("pushing manifest: %w", err)
+	}
+
+	layers := make([]ocispec.Descriptor, 0, len(b.Files)+len(b.Imports))
+	for _, f := range b.Files {
+		desc, err := pushLayer(ctx, target, f, roleArtifact)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+		layers = append(layers, desc)
+	}
+	for _, f := range b.Imports {
+		desc, err := pushLayer(ctx, target, f, roleImport)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+		layers = append(layers, desc)
+	}
+
+	return oras.PackManifest(ctx, target, oras.PackManifestVersion1_1, MediaTypeBundle, oras.PackManifestOptions{
+		ConfigDescriptor:    &manifestDesc,
+		Layers:              layers,
+		ManifestAnnotations: o.annotations,
+	})
+}
+
+func pushLayer(ctx context.Context, target content.Pusher, f File, role string) (ocispec.Descriptor, error) {
+	desc := descFromBytes(MediaTypeArtifact, f.Data)
+	desc.Annotations = map[string]string{
+		ocispec.AnnotationTitle: f.Name,
+		annotationRole:          role,
+	}
+	if err := pushBlob(ctx, target, desc, f.Data); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("pushing %s %s: %w", role, f.Name, err)
+	}
+	return desc, nil
+}
+
+func pushBlob(ctx context.Context, target content.Pusher, desc ocispec.Descriptor, data []byte) error {
+	err := target.Push(ctx, desc, bytes.NewReader(data))
+	if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		return err
+	}
+	return nil
+}
+
+func descFromBytes(mediaType string, data []byte) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		MediaType: mediaType,
+		Digest:    digest.FromBytes(data),
+		Size:      int64(len(data)),
+	}
+}

--- a/bundle/pack.go
+++ b/bundle/pack.go
@@ -70,6 +70,9 @@ func pushLayer(ctx context.Context, target content.Pusher, f File, role string) 
 		ocispec.AnnotationTitle: f.Name,
 		annotationRole:          role,
 	}
+	if f.Type != "" {
+		desc.Annotations[annotationType] = f.Type
+	}
 	if err := pushBlob(ctx, target, desc, f.Data); err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("pushing %s %s: %w", role, f.Name, err)
 	}

--- a/bundle/unpack.go
+++ b/bundle/unpack.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package bundle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+)
+
+// Unpack reads the OCI artifact at ref from target and returns a Bundle.
+// The bundle's Etag is set to the hex digest of the resolved manifest.
+func Unpack(ctx context.Context, target oras.ReadOnlyTarget, ref string) (*Bundle, error) {
+	manifestDesc, err := target.Resolve(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("resolving %q: %w", ref, err)
+	}
+
+	manifestData, err := fetchAll(ctx, target, manifestDesc)
+	if err != nil {
+		return nil, fmt.Errorf("fetching manifest: %w", err)
+	}
+
+	var ociManifest ocispec.Manifest
+	if err := json.Unmarshal(manifestData, &ociManifest); err != nil {
+		return nil, fmt.Errorf("parsing manifest: %w", err)
+	}
+
+	var m Manifest
+	if ociManifest.Config.MediaType == MediaTypeManifest {
+		configData, err := fetchAll(ctx, target, ociManifest.Config)
+		if err != nil {
+			return nil, fmt.Errorf("fetching bundle manifest: %w", err)
+		}
+		if err := json.Unmarshal(configData, &m); err != nil {
+			return nil, fmt.Errorf("parsing bundle manifest: %w", err)
+		}
+	}
+
+	b := &Bundle{
+		Manifest: m,
+		Etag:     manifestDesc.Digest.Hex(),
+	}
+
+	for _, layerDesc := range ociManifest.Layers {
+		if layerDesc.MediaType != MediaTypeArtifact {
+			continue
+		}
+
+		data, err := fetchAll(ctx, target, layerDesc)
+		if err != nil {
+			return nil, fmt.Errorf("fetching layer %s: %w", layerDesc.Digest, err)
+		}
+
+		f := File{
+			Name: layerDesc.Annotations[ocispec.AnnotationTitle],
+			Data: data,
+		}
+
+		switch layerDesc.Annotations[annotationRole] {
+		case roleImport:
+			b.Imports = append(b.Imports, f)
+		default:
+			b.Files = append(b.Files, f)
+		}
+	}
+
+	return b, nil
+}
+
+func fetchAll(ctx context.Context, target oras.ReadOnlyTarget, desc ocispec.Descriptor) ([]byte, error) {
+	rc, err := target.Fetch(ctx, desc)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close() //nolint:errcheck
+	return io.ReadAll(rc)
+}

--- a/bundle/unpack.go
+++ b/bundle/unpack.go
@@ -58,6 +58,7 @@ func Unpack(ctx context.Context, target oras.ReadOnlyTarget, ref string) (*Bundl
 
 		f := File{
 			Name: layerDesc.Annotations[ocispec.AnnotationTitle],
+			Type: layerDesc.Annotations[annotationType],
 			Data: data,
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,13 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	oras.land/oras-go/v2 v2.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,12 +15,18 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/text v0.25.0 h1:qVyWApTSYLk/drJRO5mDlNYskwQznZmkpV2c8q9zls4=
 golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -28,3 +34,5 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
+oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=

--- a/loaders.go
+++ b/loaders.go
@@ -12,6 +12,24 @@ import (
 	"github.com/gemaraproj/go-gemara/internal/codec"
 )
 
+// TypeMeta is the minimal discriminator parsed from raw YAML/JSON to
+// determine which concrete Gemara type to unmarshal into
+type TypeMeta struct {
+	Metadata struct {
+		Type ArtifactType `json:"type" yaml:"type"`
+	} `json:"metadata" yaml:"metadata"`
+}
+
+// DetectType parses only the metadata.type field from raw artifact data,
+// returning the ArtifactType without requiring a full unmarshal.
+func DetectType(data []byte) (ArtifactType, error) {
+	var tm TypeMeta
+	if err := codec.UnmarshalYAML(data, &tm); err != nil {
+		return InvalidArtifact, fmt.Errorf("reading metadata.type: %w", err)
+	}
+	return tm.Metadata.Type, nil
+}
+
 // Fetcher retrieves content from a source location.
 //
 // Network-capable implementations (e.g. [fetcher.HTTP], [fetcher.URI])


### PR DESCRIPTION
Introduce the bundle package for standardizing Gemara artifact distribution via OCI registries using oras-go.

Closes #61 