### PR TITLE
chore: bump ospo-reusable-workflows release.yaml to v1.0.1

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,6 +8,9 @@ template: |
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
 
 categories:
+  - title: "💥 Breaking Changes"
+    labels:
+      - "breaking"
   - title: "🚀 Features"
     labels:
       - "feature"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write       # Federate for artifact attestation
       attestations: write   # Generate build provenance attestations
       discussions: write    # Create release announcement discussion
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@e92cb6053ace495fe40a5f185988557afcdcecbc # v1.0.1
     with:
       publish: true
       release-config-name: release-drafter.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,45 +2,22 @@
 name: "Release"
 on:
   workflow_dispatch:
-  pull_request:
-    types: [ closed ]
-    branches:
-      - main
+  pull_request_target:
+    types: [closed]
+    branches: [main]
 jobs:
   release:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'release'))
     permissions:
-      contents: write
-      pull-requests: read
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@a0cf79bd8756e0a9c1555bf4975eae7ce7a8e8dc
+      contents: write       # Create release and push tags
+      pull-requests: read   # Read PR labels for release-drafter
+      id-token: write       # Federate for artifact attestation
+      attestations: write   # Generate artifact attestations
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true
       release-config-name: release-drafter.yml
+      goreleaser-config-path: .goreleaser.yaml
+      go-version-file: go.mod
+      create-attestation: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-  goreleaser:
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
-        with:
-          go-version-file: go.mod
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,10 @@ jobs:
     permissions:
       contents: write       # Create release and push tags
       pull-requests: read   # Read PR labels for release-drafter
+      packages: write       # Push container image to ghcr.io
       id-token: write       # Federate for artifact attestation
-      attestations: write   # Generate artifact attestations
+      attestations: write   # Generate build provenance attestations
+      discussions: write    # Create release announcement discussion
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,7 @@ changelog:
       - "^test:"
 
 release:
+  disable: true
   prerelease: auto
 
 universal_binaries:


### PR DESCRIPTION
## What

Pin the reusable release workflow to v1.0.0 (SHA 592067a69a43d2285f933753d89a7c9d51b96530), remove the local GoReleaser job in favor of the reusable workflow's built-in GoReleaser support, add release.disable to .goreleaser.yaml, and add a Breaking Changes category to release-drafter.

## Why

v1.0.0 of ospo-reusable-workflows broadens the release trigger to include breaking, feature, vuln, and release labels and folds GoReleaser, container image build, attestation, and discussion creation into the reusable workflow itself. Centralizing the GoReleaser step removes duplicated CI definition and keeps version pins on a single hardened source.

## Notes

- The reusable workflow validates that the GoReleaser config sets `release.disable: true` to prevent the goreleaser step from racing the draft release. The existing `prerelease: auto` setting is kept for completeness but is moot while disable is true.
- The outer label-filter `if:` block is removed because the v1.0 reusable workflow handles label filtering internally.
- Trigger updated to pull_request_target so the workflow can push tags via GITHUB_TOKEN.
- Attestation is now generated by the reusable workflow (via create-attestation: true); the previous separate goreleaser job did not generate attestations.

## Testing

- [ ] CI passes on this PR
- [ ] After merge, confirm the reusable workflow runs end-to-end on a labeled release PR (release/breaking/feature/vuln)
- [ ] Verify draft release is created by release-drafter and artifacts are attached by GoReleaser
- [ ] Verify artifact attestations are generated