### PR TITLE
feat!(bundle): set default bundle version and refactor bundle source handling

### DIFF
--- a/bundle/assemble.go
+++ b/bundle/assemble.go
@@ -70,32 +70,26 @@ func parseFile(f File) (*parsedFile, error) {
 	return pf, nil
 }
 
-// Assemble parses each source file, fetches every artifact referenced in
-// their extends and imports via mapping-references URLs, then
-// recursively parses fetched artifacts for their own references until the
-// full dependency tree is resolved.
-func (a *Assembler) Assemble(ctx context.Context, m Manifest, sources ...File) (*Bundle, error) {
-	if len(sources) == 0 {
-		return nil, fmt.Errorf("at least one source file is required")
+// Assemble parses the source file, fetches every artifact referenced in
+// its extends and imports via mapping-references URLs, then recursively
+// parses fetched artifacts for their own references until the full
+// dependency tree is resolved.
+func (a *Assembler) Assemble(ctx context.Context, m Manifest, source File) (*Bundle, error) {
+	if source.Name == "" {
+		return nil, fmt.Errorf("source file is required")
 	}
 
 	seen := make(map[string]bool)
 	depMap := make(map[string][]string)
 
-	var sourceParsed []*parsedFile
-	var queue []fetchRef
-
-	for _, f := range sources {
-		pf, err := parseFile(f)
-		if err != nil {
-			return nil, err
-		}
-		sourceParsed = append(sourceParsed, pf)
-		queue = append(queue, enqueueRefs(pf, seen, depMap)...)
+	sourceParsed, err := parseFile(source)
+	if err != nil {
+		return nil, err
 	}
+	queue := enqueueRefs(sourceParsed, seen, depMap)
 
-	if m.BundleVersion == "" && len(sourceParsed) > 0 {
-		m.BundleVersion = sourceParsed[0].version
+	if m.BundleVersion == "" {
+		m.BundleVersion = sourceParsed.version
 	}
 
 	var importParsed []*parsedFile
@@ -127,9 +121,6 @@ func (a *Assembler) Assemble(ctx context.Context, m Manifest, sources ...File) (
 		queue = append(queue, enqueueRefs(pf, seen, depMap)...)
 	}
 
-	files := make([]File, len(sources))
-	copy(files, sources)
-
 	var imports []File
 	for _, pf := range importParsed {
 		imports = append(imports, pf.File)
@@ -139,7 +130,7 @@ func (a *Assembler) Assemble(ctx context.Context, m Manifest, sources ...File) (
 
 	return &Bundle{
 		Manifest: m,
-		Files:    files,
+		Source:   source,
 		Imports:  imports,
 	}, nil
 }
@@ -221,18 +212,16 @@ func policyRefIDs(imports gemara.Imports) []string {
 }
 
 // buildArtifactTree constructs the Manifest.Artifacts slice from the
-// already-parsed files and their dependency relationships.
-func buildArtifactTree(files, imports []*parsedFile, depMap map[string][]string) []Artifact {
-	artifacts := make([]Artifact, 0, len(files)+len(imports))
-	for _, pf := range files {
-		artifacts = append(artifacts, Artifact{
-			Name:         pf.Name,
-			Type:         pf.artType.String(),
-			ID:           pf.id,
-			Role:         roleArtifact,
-			Dependencies: depMap[pf.Name],
-		})
-	}
+// parsed source and its dependency relationships.
+func buildArtifactTree(source *parsedFile, imports []*parsedFile, depMap map[string][]string) []Artifact {
+	artifacts := make([]Artifact, 0, 1+len(imports))
+	artifacts = append(artifacts, Artifact{
+		Name:         source.Name,
+		Type:         source.artType.String(),
+		ID:           source.id,
+		Role:         roleArtifact,
+		Dependencies: depMap[source.Name],
+	})
 	for _, pf := range imports {
 		artifacts = append(artifacts, Artifact{
 			Name:         pf.Name,

--- a/bundle/assemble.go
+++ b/bundle/assemble.go
@@ -28,6 +28,7 @@ func NewAssembler(f gemara.Fetcher) *Assembler {
 type parsedFile struct {
 	File
 	id      string
+	version string
 	artType gemara.ArtifactType
 	refIDs  []string
 	refURLs map[string]string
@@ -50,6 +51,7 @@ func parseFile(f File) (*parsedFile, error) {
 			return nil, fmt.Errorf("parsing %s: %w", f.Name, err)
 		}
 		pf.id = pol.Metadata.Id
+		pf.version = pol.Metadata.Version
 		pf.artType = pol.Metadata.Type
 		pf.refURLs = mappingRefURLs(pol.Metadata.MappingReferences)
 		pf.refIDs = policyRefIDs(pol.Imports)
@@ -59,6 +61,7 @@ func parseFile(f File) (*parsedFile, error) {
 			return nil, fmt.Errorf("parsing %s: %w", f.Name, err)
 		}
 		pf.id = cat.Metadata.Id
+		pf.version = cat.Metadata.Version
 		pf.artType = cat.Metadata.Type
 		pf.refURLs = mappingRefURLs(cat.Metadata.MappingReferences)
 		pf.refIDs = catalogRefIDs(cat.Extends, cat.Imports)
@@ -89,6 +92,10 @@ func (a *Assembler) Assemble(ctx context.Context, m Manifest, sources ...File) (
 		}
 		sourceParsed = append(sourceParsed, pf)
 		queue = append(queue, enqueueRefs(pf, seen, depMap)...)
+	}
+
+	if m.BundleVersion == "" && len(sourceParsed) > 0 {
+		m.BundleVersion = sourceParsed[0].version
 	}
 
 	var importParsed []*parsedFile

--- a/bundle/assemble_test.go
+++ b/bundle/assemble_test.go
@@ -40,12 +40,17 @@ var testAuthor = gemara.Actor{
 }
 
 func testControlCatalog(id string, refs []gemara.MappingReference, extends []gemara.ArtifactMapping, imports []gemara.MultiEntryMapping) gemara.Catalog {
+	return testControlCatalogWithVersion(id, "", refs, extends, imports)
+}
+
+func testControlCatalogWithVersion(id, version string, refs []gemara.MappingReference, extends []gemara.ArtifactMapping, imports []gemara.MultiEntryMapping) gemara.Catalog {
 	return gemara.Catalog{
 		Title: "Test Catalog",
 		Metadata: gemara.Metadata{
 			Id:                id,
 			Type:              gemara.ControlCatalogArtifact,
 			GemaraVersion:     "1.0.0",
+			Version:           version,
 			Description:       "test catalog",
 			Author:            testAuthor,
 			MappingReferences: refs,
@@ -427,6 +432,48 @@ func TestImportFileName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.refID+"_"+tt.url, func(t *testing.T) {
 			assert.Equal(t, tt.want, importFileName(tt.refID, tt.url))
+		})
+	}
+}
+
+func TestAssembler_Assemble_BundleVersionDefault(t *testing.T) {
+	tests := []struct {
+		name            string
+		manifest        Manifest
+		sourceVersion   string
+		wantBundleVer   string
+	}{
+		{
+			name:          "defaults BundleVersion from first source artifact",
+			manifest:      Manifest{GemaraVersion: "v1.0.0"},
+			sourceVersion: "2.3.0",
+			wantBundleVer: "2.3.0",
+		},
+		{
+			name:          "preserves explicit BundleVersion",
+			manifest:      Manifest{BundleVersion: "explicit-1.0", GemaraVersion: "v1.0.0"},
+			sourceVersion: "2.3.0",
+			wantBundleVer: "explicit-1.0",
+		},
+		{
+			name:          "empty artifact version produces empty BundleVersion",
+			manifest:      Manifest{GemaraVersion: "v1.0.0"},
+			sourceVersion: "",
+			wantBundleVer: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asm := NewAssembler(mapFetcher{})
+			source := File{
+				Name: "controls.yaml",
+				Data: mustMarshal(t, testControlCatalogWithVersion("cat-1", tt.sourceVersion, nil, nil, nil)),
+			}
+			b, err := asm.Assemble(context.Background(), tt.manifest, source)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantBundleVer, b.Manifest.BundleVersion)
+			assert.Equal(t, tt.wantBundleVer, b.Version())
 		})
 	}
 }

--- a/bundle/assemble_test.go
+++ b/bundle/assemble_test.go
@@ -79,7 +79,7 @@ func TestAssembler_Assemble(t *testing.T) {
 	tests := []struct {
 		name    string
 		fetcher mapFetcher
-		sources []File
+		source  File
 		wantErr string
 		check   func(t *testing.T, b *Bundle)
 	}{
@@ -88,26 +88,23 @@ func TestAssembler_Assemble(t *testing.T) {
 			fetcher: mapFetcher{
 				"https://example.com/guidance.yaml": mustMarshal(t, guidance),
 			},
-			sources: []File{
-				{
-					Name: "controls.yaml",
-					Data: mustMarshal(t, testControlCatalog("test-cat",
-						[]gemara.MappingReference{
-							{Id: "EXT-GUIDE", Title: "External Guidance", Version: "1.0", Url: "https://example.com/guidance.yaml"},
-							{Id: "LOCAL-REF", Title: "Local Only", Version: "1.0"},
-						},
-						nil,
-						[]gemara.MultiEntryMapping{
-							{ReferenceId: "EXT-GUIDE", Entries: []gemara.ArtifactMapping{{ReferenceId: "G1"}}},
-						},
-					)),
-				},
+			source: File{
+				Name: "controls.yaml",
+				Data: mustMarshal(t, testControlCatalog("test-cat",
+					[]gemara.MappingReference{
+						{Id: "EXT-GUIDE", Title: "External Guidance", Version: "1.0", Url: "https://example.com/guidance.yaml"},
+						{Id: "LOCAL-REF", Title: "Local Only", Version: "1.0"},
+					},
+					nil,
+					[]gemara.MultiEntryMapping{
+						{ReferenceId: "EXT-GUIDE", Entries: []gemara.ArtifactMapping{{ReferenceId: "G1"}}},
+					},
+				)),
 			},
 			check: func(t *testing.T, b *Bundle) {
 				assert.Equal(t, "1", b.Manifest.BundleVersion)
 				assert.Equal(t, "v1.0.0", b.Manifest.GemaraVersion)
-				require.Len(t, b.Files, 1)
-				assert.Equal(t, "controls.yaml", b.Files[0].Name)
+				assert.Equal(t, "controls.yaml", b.Source.Name)
 				require.Len(t, b.Imports, 1)
 				assert.Equal(t, "guidance.yaml", b.Imports[0].Name)
 
@@ -119,40 +116,18 @@ func TestAssembler_Assemble(t *testing.T) {
 		{
 			name:    "skips mapping ref without URL",
 			fetcher: mapFetcher{},
-			sources: []File{
-				{
-					Name: "a.yaml",
-					Data: mustMarshal(t, testControlCatalog("test-cat",
-						[]gemara.MappingReference{{Id: "NO-URL", Title: "No URL", Version: "1.0"}},
-						nil,
-						[]gemara.MultiEntryMapping{
-							{ReferenceId: "NO-URL", Entries: []gemara.ArtifactMapping{{ReferenceId: "x"}}},
-						},
-					)),
-				},
+			source: File{
+				Name: "a.yaml",
+				Data: mustMarshal(t, testControlCatalog("test-cat",
+					[]gemara.MappingReference{{Id: "NO-URL", Title: "No URL", Version: "1.0"}},
+					nil,
+					[]gemara.MultiEntryMapping{
+						{ReferenceId: "NO-URL", Entries: []gemara.ArtifactMapping{{ReferenceId: "x"}}},
+					},
+				)),
 			},
 			check: func(t *testing.T, b *Bundle) {
 				assert.Nil(t, b.Imports)
-			},
-		},
-		{
-			name: "deduplicates shared dependency across sources",
-			fetcher: mapFetcher{
-				"https://example.com/shared.yaml": mustMarshal(t, testControlCatalog("shared", nil, nil, nil)),
-			},
-			sources: func() []File {
-				data := mustMarshal(t, testControlCatalog("test-cat",
-					[]gemara.MappingReference{{Id: "SHARED", Title: "Shared", Version: "1.0", Url: "https://example.com/shared.yaml"}},
-					nil,
-					[]gemara.MultiEntryMapping{
-						{ReferenceId: "SHARED", Entries: []gemara.ArtifactMapping{{ReferenceId: "x"}}},
-					},
-				))
-				return []File{{Name: "a.yaml", Data: data}, {Name: "b.yaml", Data: data}}
-			}(),
-			check: func(t *testing.T, b *Bundle) {
-				require.Len(t, b.Imports, 1, "duplicate import should be fetched once")
-				assert.Equal(t, "shared.yaml", b.Imports[0].Name)
 			},
 		},
 		{
@@ -160,15 +135,13 @@ func TestAssembler_Assemble(t *testing.T) {
 			fetcher: mapFetcher{
 				"https://example.com/base.yaml": mustMarshal(t, testControlCatalog("base", nil, nil, nil)),
 			},
-			sources: []File{
-				{
-					Name: "child.yaml",
-					Data: mustMarshal(t, testControlCatalog("child",
-						[]gemara.MappingReference{{Id: "BASE", Title: "Base Catalog", Version: "1.0", Url: "https://example.com/base.yaml"}},
-						[]gemara.ArtifactMapping{{ReferenceId: "BASE", Remarks: "builds upon base"}},
-						nil,
-					)),
-				},
+			source: File{
+				Name: "child.yaml",
+				Data: mustMarshal(t, testControlCatalog("child",
+					[]gemara.MappingReference{{Id: "BASE", Title: "Base Catalog", Version: "1.0", Url: "https://example.com/base.yaml"}},
+					[]gemara.ArtifactMapping{{ReferenceId: "BASE", Remarks: "builds upon base"}},
+					nil,
+				)),
 			},
 			check: func(t *testing.T, b *Bundle) {
 				require.Len(t, b.Imports, 1)
@@ -181,20 +154,18 @@ func TestAssembler_Assemble(t *testing.T) {
 				"https://example.com/base.yaml":  mustMarshal(t, testControlCatalog("base", nil, nil, nil)),
 				"https://example.com/guide.yaml": mustMarshal(t, testGuidanceCatalog("guide")),
 			},
-			sources: []File{
-				{
-					Name: "c.yaml",
-					Data: mustMarshal(t, testControlCatalog("combined",
-						[]gemara.MappingReference{
-							{Id: "BASE", Title: "Base", Version: "1.0", Url: "https://example.com/base.yaml"},
-							{Id: "GUIDE", Title: "Guide", Version: "1.0", Url: "https://example.com/guide.yaml"},
-						},
-						[]gemara.ArtifactMapping{{ReferenceId: "BASE"}},
-						[]gemara.MultiEntryMapping{
-							{ReferenceId: "GUIDE", Entries: []gemara.ArtifactMapping{{ReferenceId: "G1"}}},
-						},
-					)),
-				},
+			source: File{
+				Name: "c.yaml",
+				Data: mustMarshal(t, testControlCatalog("combined",
+					[]gemara.MappingReference{
+						{Id: "BASE", Title: "Base", Version: "1.0", Url: "https://example.com/base.yaml"},
+						{Id: "GUIDE", Title: "Guide", Version: "1.0", Url: "https://example.com/guide.yaml"},
+					},
+					[]gemara.ArtifactMapping{{ReferenceId: "BASE"}},
+					[]gemara.MultiEntryMapping{
+						{ReferenceId: "GUIDE", Entries: []gemara.ArtifactMapping{{ReferenceId: "G1"}}},
+					},
+				)),
 			},
 			check: func(t *testing.T, b *Bundle) {
 				require.Len(t, b.Imports, 2)
@@ -209,35 +180,33 @@ func TestAssembler_Assemble(t *testing.T) {
 				"https://example.com/controls.yaml": mustMarshal(t, testControlCatalog("ctrl", nil, nil, nil)),
 				"https://example.com/guidance.yaml": mustMarshal(t, testGuidanceCatalog("guide")),
 			},
-			sources: []File{
-				{
-					Name: "policy.yaml",
-					Data: mustMarshal(t, gemara.Policy{
-						Title: "Org Policy",
-						Metadata: gemara.Metadata{
-							Id: "org-policy", Type: gemara.PolicyArtifact, GemaraVersion: "1.0.0",
-							Description: "org-wide policy", Author: testAuthor,
-							MappingReferences: []gemara.MappingReference{
-								{Id: "CTRL", Title: "Control Catalog", Version: "1.0", Url: "https://example.com/controls.yaml"},
-								{Id: "GUIDE", Title: "Guidance Doc", Version: "1.0", Url: "https://example.com/guidance.yaml"},
-							},
+			source: File{
+				Name: "policy.yaml",
+				Data: mustMarshal(t, gemara.Policy{
+					Title: "Org Policy",
+					Metadata: gemara.Metadata{
+						Id: "org-policy", Type: gemara.PolicyArtifact, GemaraVersion: "1.0.0",
+						Description: "org-wide policy", Author: testAuthor,
+						MappingReferences: []gemara.MappingReference{
+							{Id: "CTRL", Title: "Control Catalog", Version: "1.0", Url: "https://example.com/controls.yaml"},
+							{Id: "GUIDE", Title: "Guidance Doc", Version: "1.0", Url: "https://example.com/guidance.yaml"},
 						},
-						Contacts: gemara.RACI{
-							Responsible: []gemara.Contact{{Name: "R"}},
-							Accountable: []gemara.Contact{{Name: "A"}},
+					},
+					Contacts: gemara.RACI{
+						Responsible: []gemara.Contact{{Name: "R"}},
+						Accountable: []gemara.Contact{{Name: "A"}},
+					},
+					Scope: gemara.Scope{In: gemara.Dimensions{Technologies: []string{"cloud"}}},
+					Imports: gemara.Imports{
+						Catalogs: []gemara.CatalogImport{{ReferenceId: "CTRL"}},
+						Guidance: []gemara.GuidanceImport{{ReferenceId: "GUIDE"}},
+					},
+					Adherence: gemara.Adherence{
+						EvaluationMethods: []gemara.AcceptedMethod{
+							{Id: "em1", Type: gemara.MethodGate, Mode: gemara.ModeAutomated, Required: true},
 						},
-						Scope: gemara.Scope{In: gemara.Dimensions{Technologies: []string{"cloud"}}},
-						Imports: gemara.Imports{
-							Catalogs: []gemara.CatalogImport{{ReferenceId: "CTRL"}},
-							Guidance: []gemara.GuidanceImport{{ReferenceId: "GUIDE"}},
-						},
-						Adherence: gemara.Adherence{
-							EvaluationMethods: []gemara.AcceptedMethod{
-								{Id: "em1", Type: gemara.MethodGate, Mode: gemara.ModeAutomated, Required: true},
-							},
-						},
-					}),
-				},
+					},
+				}),
 			},
 			check: func(t *testing.T, b *Bundle) {
 				require.Len(t, b.Imports, 2)
@@ -249,37 +218,33 @@ func TestAssembler_Assemble(t *testing.T) {
 		{
 			name:    "no imports produces single artifact",
 			fetcher: mapFetcher{},
-			sources: []File{
-				{Name: "e.yaml", Data: mustMarshal(t, testControlCatalog("e", nil, nil, nil))},
-			},
+			source:  File{Name: "e.yaml", Data: mustMarshal(t, testControlCatalog("e", nil, nil, nil))},
 			check: func(t *testing.T, b *Bundle) {
 				assert.Nil(t, b.Imports)
-				require.Len(t, b.Files, 1)
+				assert.Equal(t, "e.yaml", b.Source.Name)
 				require.Len(t, b.Manifest.Artifacts, 1)
 				assert.Equal(t, roleArtifact, b.Manifest.Artifacts[0].Role)
 				assert.Nil(t, b.Manifest.Artifacts[0].Dependencies)
 			},
 		},
 		{
-			name:    "no sources returns error",
+			name:    "empty source returns error",
 			fetcher: mapFetcher{},
-			sources: nil,
-			wantErr: "at least one source",
+			source:  File{},
+			wantErr: "source file is required",
 		},
 		{
 			name:    "fetch failure propagates error",
 			fetcher: mapFetcher{},
-			sources: []File{
-				{
-					Name: "c.yaml",
-					Data: mustMarshal(t, testControlCatalog("test-cat",
-						[]gemara.MappingReference{{Id: "EXT-GUIDE", Title: "External Guidance", Version: "1.0", Url: "https://example.com/guidance.yaml"}},
-						nil,
-						[]gemara.MultiEntryMapping{
-							{ReferenceId: "EXT-GUIDE", Entries: []gemara.ArtifactMapping{{ReferenceId: "G1"}}},
-						},
-					)),
-				},
+			source: File{
+				Name: "c.yaml",
+				Data: mustMarshal(t, testControlCatalog("test-cat",
+					[]gemara.MappingReference{{Id: "EXT-GUIDE", Title: "External Guidance", Version: "1.0", Url: "https://example.com/guidance.yaml"}},
+					nil,
+					[]gemara.MultiEntryMapping{
+						{ReferenceId: "EXT-GUIDE", Entries: []gemara.ArtifactMapping{{ReferenceId: "G1"}}},
+					},
+				)),
 			},
 			wantErr: "fetching dependency",
 		},
@@ -290,7 +255,7 @@ func TestAssembler_Assemble(t *testing.T) {
 			asm := NewAssembler(tt.fetcher)
 			m := Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"}
 
-			b, err := asm.Assemble(context.Background(), m, tt.sources...)
+			b, err := asm.Assemble(context.Background(), m, tt.source)
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
@@ -327,8 +292,7 @@ func TestAssembler_Assemble_TransitiveDeps(t *testing.T) {
 				)),
 			},
 			check: func(t *testing.T, b *Bundle) {
-				require.Len(t, b.Files, 1)
-				assert.Equal(t, "catalog-a.yaml", b.Files[0].Name)
+				assert.Equal(t, "catalog-a.yaml", b.Source.Name)
 				require.Len(t, b.Imports, 2, "both B and C should be assembled transitively")
 				names := importNames(b)
 				assert.True(t, names["catalog-b.yaml"], "direct dependency B")
@@ -438,13 +402,13 @@ func TestImportFileName(t *testing.T) {
 
 func TestAssembler_Assemble_BundleVersionDefault(t *testing.T) {
 	tests := []struct {
-		name            string
-		manifest        Manifest
-		sourceVersion   string
-		wantBundleVer   string
+		name          string
+		manifest      Manifest
+		sourceVersion string
+		wantBundleVer string
 	}{
 		{
-			name:          "defaults BundleVersion from first source artifact",
+			name:          "defaults BundleVersion from source artifact",
 			manifest:      Manifest{GemaraVersion: "v1.0.0"},
 			sourceVersion: "2.3.0",
 			wantBundleVer: "2.3.0",

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -95,16 +95,30 @@ func (b *Bundle) SetSizeLimitBytes(n int64) {
 	b.sizeLimitBytes = n
 }
 
+// Version returns the bundle version from the manifest.
+func (b *Bundle) Version() string {
+	return b.Manifest.BundleVersion
+}
+
 // PackOption configures Pack behaviour.
 type PackOption func(*packOptions)
 
 type packOptions struct {
 	annotations map[string]string
+	version     *string
 }
 
 // WithAnnotations adds custom annotations to the OCI manifest.
 func WithAnnotations(annotations map[string]string) PackOption {
 	return func(o *packOptions) {
 		o.annotations = annotations
+	}
+}
+
+// WithVersion overrides the bundle's Manifest.BundleVersion at pack time.
+// When not set, the version assembled from the main artifact metadata is used.
+func WithVersion(v string) PackOption {
+	return func(o *packOptions) {
+		o.version = &v
 	}
 }

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -71,8 +71,8 @@ type File struct {
 type Bundle struct {
 	// Manifest is the OCI config blob describing the bundle contents.
 	Manifest Manifest
-	// Files are the primary artifact files provided as assembly sources.
-	Files []File
+	// Source is the primary artifact file that anchors this bundle.
+	Source File
 	// Imports are the resolved transitive dependency files.
 	Imports []File
 	// Etag is the OCI manifest digest used for cache comparison.

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -166,6 +166,57 @@ func TestPack_Errors(t *testing.T) {
 	}
 }
 
+func TestPack_WithVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		initial    string
+		override   string
+		wantVer    string
+	}{
+		{
+			name:     "overrides existing BundleVersion",
+			initial:  "1.0.0",
+			override: "2.0.0",
+			wantVer:  "2.0.0",
+		},
+		{
+			name:     "sets BundleVersion when empty",
+			initial:  "",
+			override: "3.0.0",
+			wantVer:  "3.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := memory.New()
+
+			b := &Bundle{
+				Manifest: Manifest{BundleVersion: tt.initial, GemaraVersion: "v1.0.0"},
+				Files:    []File{{Name: "c.yaml", Data: []byte("data")}},
+			}
+			desc, err := Pack(ctx, store, b, WithVersion(tt.override))
+			require.NoError(t, err)
+			require.NotEmpty(t, desc.Digest)
+			require.NoError(t, store.Tag(ctx, desc, "v"))
+
+			got, err := Unpack(ctx, store, "v")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantVer, got.Manifest.BundleVersion)
+			assert.Equal(t, tt.wantVer, got.Version())
+		})
+	}
+}
+
+func TestBundle_Version(t *testing.T) {
+	b := &Bundle{Manifest: Manifest{BundleVersion: "4.5.6"}}
+	assert.Equal(t, "4.5.6", b.Version())
+
+	b = &Bundle{}
+	assert.Equal(t, "", b.Version())
+}
+
 func TestUnpack_BadRef(t *testing.T) {
 	_, err := Unpack(context.Background(), memory.New(), "does-not-exist")
 	assert.Error(t, err)

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -3,9 +3,13 @@
 package bundle
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 
+	godigest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"oras.land/oras-go/v2/content/memory"
@@ -189,6 +193,7 @@ func TestPack_WithVersion(t *testing.T) {
 			desc, err := Pack(ctx, store, b, WithVersion(tt.override))
 			require.NoError(t, err)
 			require.NotEmpty(t, desc.Digest)
+			assert.Equal(t, tt.initial, b.Manifest.BundleVersion, "Pack must not mutate the caller's Bundle")
 			require.NoError(t, store.Tag(ctx, desc, "v"))
 
 			got, err := Unpack(ctx, store, "v")
@@ -205,6 +210,43 @@ func TestBundle_Version(t *testing.T) {
 
 	b = &Bundle{}
 	assert.Equal(t, "", b.Version())
+}
+
+func TestUnpack_MultipleSourcesError(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+
+	b := &Bundle{
+		Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
+		Source:   File{Name: "a.yaml", Data: []byte("first")},
+		Imports:  []File{{Name: "b.yaml", Data: []byte("import")}},
+	}
+	desc, err := Pack(ctx, store, b)
+	require.NoError(t, err)
+
+	// Push a second artifact-role layer into the same manifest to
+	// simulate a bundle produced by an older multi-source format.
+	extraDesc, err := pushLayer(ctx, store, File{Name: "c.yaml", Data: []byte("second")}, roleArtifact)
+	require.NoError(t, err)
+
+	manifestData, err := fetchAll(ctx, store, desc)
+	require.NoError(t, err)
+	var ociManifest ocispec.Manifest
+	require.NoError(t, json.Unmarshal(manifestData, &ociManifest))
+	ociManifest.Layers = append(ociManifest.Layers, extraDesc)
+
+	modifiedManifest, err := json.Marshal(ociManifest)
+	require.NoError(t, err)
+	modifiedDesc := ocispec.Descriptor{
+		MediaType: ociManifest.MediaType,
+		Digest:    godigest.FromBytes(modifiedManifest),
+		Size:      int64(len(modifiedManifest)),
+	}
+	require.NoError(t, store.Push(ctx, modifiedDesc, bytes.NewReader(modifiedManifest)))
+	require.NoError(t, store.Tag(ctx, modifiedDesc, "multi-source"))
+
+	_, err = Unpack(ctx, store, "multi-source")
+	assert.ErrorContains(t, err, "multiple source artifacts")
 }
 
 func TestUnpack_BadRef(t *testing.T) {

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -21,12 +21,10 @@ func TestPackUnpack(t *testing.T) {
 		check   func(t *testing.T, original *Bundle, got *Bundle)
 	}{
 		{
-			name: "round trip preserves files and imports",
+			name: "round trip preserves source and imports",
 			bundle: &Bundle{
 				Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
-				Files: []File{
-					{Name: "controls.yaml", Type: "ControlCatalog", Data: []byte("id: ctrl-catalog\ncontrols: []")},
-				},
+				Source:   File{Name: "controls.yaml", Type: "ControlCatalog", Data: []byte("id: ctrl-catalog\ncontrols: []")},
 				Imports: []File{
 					{Name: "imported-guidance.yaml", Type: "GuidanceCatalog", Data: []byte("id: guidance-import\nguidelines: []")},
 				},
@@ -35,10 +33,9 @@ func TestPackUnpack(t *testing.T) {
 			check: func(t *testing.T, original *Bundle, got *Bundle) {
 				assert.Equal(t, original.Manifest, got.Manifest)
 				assert.NotEmpty(t, got.Etag)
-				require.Len(t, got.Files, 1)
-				assert.Equal(t, "controls.yaml", got.Files[0].Name)
-				assert.Equal(t, "ControlCatalog", got.Files[0].Type)
-				assert.Equal(t, original.Files[0].Data, got.Files[0].Data)
+				assert.Equal(t, "controls.yaml", got.Source.Name)
+				assert.Equal(t, "ControlCatalog", got.Source.Type)
+				assert.Equal(t, original.Source.Data, got.Source.Data)
 				require.Len(t, got.Imports, 1)
 				assert.Equal(t, "imported-guidance.yaml", got.Imports[0].Name)
 				assert.Equal(t, "GuidanceCatalog", got.Imports[0].Type)
@@ -46,20 +43,15 @@ func TestPackUnpack(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple files without imports",
+			name: "source without imports",
 			bundle: &Bundle{
 				Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
-				Files: []File{
-					{Name: "controls.yaml", Type: "ControlCatalog", Data: []byte("controls: [one]")},
-					{Name: "threats.yaml", Type: "ThreatCatalog", Data: []byte("threats: [two]")},
-				},
+				Source:   File{Name: "controls.yaml", Type: "ControlCatalog", Data: []byte("controls: [one]")},
 			},
 			tag: "latest",
 			check: func(t *testing.T, original *Bundle, got *Bundle) {
 				assert.Equal(t, original.Manifest, got.Manifest)
-				require.Len(t, got.Files, 2)
-				assert.Equal(t, "ControlCatalog", got.Files[0].Type)
-				assert.Equal(t, "ThreatCatalog", got.Files[1].Type)
+				assert.Equal(t, "ControlCatalog", got.Source.Type)
 				assert.Nil(t, got.Imports)
 			},
 		},
@@ -67,26 +59,25 @@ func TestPackUnpack(t *testing.T) {
 			name: "custom annotations propagated",
 			bundle: &Bundle{
 				Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
-				Files:    []File{{Name: "c.yaml", Data: []byte("data")}},
+				Source:   File{Name: "c.yaml", Data: []byte("data")},
 			},
 			tag:  "annotated",
 			opts: []PackOption{WithAnnotations(map[string]string{"org.example.source": "ci"})},
 			check: func(t *testing.T, _ *Bundle, got *Bundle) {
-				require.Len(t, got.Files, 1)
+				assert.Equal(t, "c.yaml", got.Source.Name)
 			},
 		},
 		{
-			name: "duplicate content across files and imports",
+			name: "duplicate content across source and imports",
 			bundle: &Bundle{
 				Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
-				Files:    []File{{Name: "a.yaml", Data: []byte("identical content")}},
+				Source:   File{Name: "a.yaml", Data: []byte("identical content")},
 				Imports:  []File{{Name: "b.yaml", Data: []byte("identical content")}},
 			},
 			tag: "dup",
 			check: func(t *testing.T, _ *Bundle, got *Bundle) {
-				require.Len(t, got.Files, 1)
+				assert.Equal(t, "a.yaml", got.Source.Name)
 				require.Len(t, got.Imports, 1)
-				assert.Equal(t, "a.yaml", got.Files[0].Name)
 				assert.Equal(t, "b.yaml", got.Imports[0].Name)
 			},
 		},
@@ -94,12 +85,11 @@ func TestPackUnpack(t *testing.T) {
 			name: "omitted type round-trips as empty string",
 			bundle: &Bundle{
 				Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
-				Files:    []File{{Name: "plain.yaml", Data: []byte("data")}},
+				Source:   File{Name: "plain.yaml", Data: []byte("data")},
 			},
 			tag: "no-type",
 			check: func(t *testing.T, _ *Bundle, got *Bundle) {
-				require.Len(t, got.Files, 1)
-				assert.Empty(t, got.Files[0].Type)
+				assert.Empty(t, got.Source.Type)
 			},
 		},
 	}
@@ -131,7 +121,7 @@ func TestPackUnpack_Annotations(t *testing.T) {
 
 	b := &Bundle{
 		Manifest: Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"},
-		Files:    []File{{Name: "c.yaml", Data: []byte("data")}},
+		Source:   File{Name: "c.yaml", Data: []byte("data")},
 	}
 	desc, err := Pack(ctx, store, b, WithAnnotations(map[string]string{
 		"org.example.source": "ci",
@@ -152,9 +142,9 @@ func TestPack_Errors(t *testing.T) {
 			wantErr: "bundle must not be nil",
 		},
 		{
-			name:    "empty files",
+			name:    "empty source",
 			bundle:  &Bundle{},
-			wantErr: "at least one artifact file",
+			wantErr: "source artifact",
 		},
 	}
 
@@ -168,10 +158,10 @@ func TestPack_Errors(t *testing.T) {
 
 func TestPack_WithVersion(t *testing.T) {
 	tests := []struct {
-		name       string
-		initial    string
-		override   string
-		wantVer    string
+		name     string
+		initial  string
+		override string
+		wantVer  string
 	}{
 		{
 			name:     "overrides existing BundleVersion",
@@ -194,7 +184,7 @@ func TestPack_WithVersion(t *testing.T) {
 
 			b := &Bundle{
 				Manifest: Manifest{BundleVersion: tt.initial, GemaraVersion: "v1.0.0"},
-				Files:    []File{{Name: "c.yaml", Data: []byte("data")}},
+				Source:   File{Name: "c.yaml", Data: []byte("data")},
 			}
 			desc, err := Pack(ctx, store, b, WithVersion(tt.override))
 			require.NoError(t, err)

--- a/bundle/pack.go
+++ b/bundle/pack.go
@@ -32,11 +32,12 @@ func Pack(ctx context.Context, target oras.Target, b *Bundle, opts ...PackOption
 		opt(o)
 	}
 
+	m := b.Manifest
 	if o.version != nil {
-		b.Manifest.BundleVersion = *o.version
+		m.BundleVersion = *o.version
 	}
 
-	manifestData, err := json.Marshal(b.Manifest)
+	manifestData, err := json.Marshal(m)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("marshaling manifest: %w", err)
 	}

--- a/bundle/pack.go
+++ b/bundle/pack.go
@@ -23,8 +23,8 @@ func Pack(ctx context.Context, target oras.Target, b *Bundle, opts ...PackOption
 	if b == nil {
 		return ocispec.Descriptor{}, fmt.Errorf("bundle must not be nil")
 	}
-	if len(b.Files) == 0 {
-		return ocispec.Descriptor{}, fmt.Errorf("bundle must contain at least one artifact file")
+	if b.Source.Name == "" {
+		return ocispec.Descriptor{}, fmt.Errorf("bundle must contain a source artifact")
 	}
 
 	o := &packOptions{}
@@ -45,14 +45,12 @@ func Pack(ctx context.Context, target oras.Target, b *Bundle, opts ...PackOption
 		return ocispec.Descriptor{}, fmt.Errorf("pushing manifest: %w", err)
 	}
 
-	layers := make([]ocispec.Descriptor, 0, len(b.Files)+len(b.Imports))
-	for _, f := range b.Files {
-		desc, err := pushLayer(ctx, target, f, roleArtifact)
-		if err != nil {
-			return ocispec.Descriptor{}, err
-		}
-		layers = append(layers, desc)
+	layers := make([]ocispec.Descriptor, 0, 1+len(b.Imports))
+	sourceDesc, err := pushLayer(ctx, target, b.Source, roleArtifact)
+	if err != nil {
+		return ocispec.Descriptor{}, err
 	}
+	layers = append(layers, sourceDesc)
 	for _, f := range b.Imports {
 		desc, err := pushLayer(ctx, target, f, roleImport)
 		if err != nil {

--- a/bundle/pack.go
+++ b/bundle/pack.go
@@ -32,6 +32,10 @@ func Pack(ctx context.Context, target oras.Target, b *Bundle, opts ...PackOption
 		opt(o)
 	}
 
+	if o.version != nil {
+		b.Manifest.BundleVersion = *o.version
+	}
+
 	manifestData, err := json.Marshal(b.Manifest)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("marshaling manifest: %w", err)

--- a/bundle/unpack.go
+++ b/bundle/unpack.go
@@ -66,6 +66,9 @@ func Unpack(ctx context.Context, target oras.ReadOnlyTarget, ref string) (*Bundl
 		case roleImport:
 			b.Imports = append(b.Imports, f)
 		default:
+			if b.Source.Name != "" {
+				return nil, fmt.Errorf("bundle contains multiple source artifacts; expected exactly one")
+			}
 			b.Source = f
 		}
 	}

--- a/bundle/unpack.go
+++ b/bundle/unpack.go
@@ -66,7 +66,7 @@ func Unpack(ctx context.Context, target oras.ReadOnlyTarget, ref string) (*Bundl
 		case roleImport:
 			b.Imports = append(b.Imports, f)
 		default:
-			b.Files = append(b.Files, f)
+			b.Source = f
 		}
 	}
 


### PR DESCRIPTION
Assemble now sets Manifest.BundleVersion from the source artifact's Metadata.Version when no explicit version is provided. To detect a bundle version with sane defaults (i.e. the version of the Gemara Policy), a bundle has exactly one root artifact.

Ref #60 