### PR TITLE
fix: replace url.Parse with PathUnescape in URI.Fetch file:// handler 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,22 @@ on:
       - main
 
 jobs:
+  test-windows:
+    runs-on: windows-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version: stable
+      - name: Unit tests
+        run: go test ./...
+
   CI:
     runs-on: ubuntu-latest
 

--- a/fetcher/uri.go
+++ b/fetcher/uri.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -25,6 +26,18 @@ import (
 // documentation for security considerations.
 type URI struct {
 	Client *http.Client
+}
+
+// FileURI converts an OS-native absolute path to a valid RFC 8089 file:/// URI.
+// On Unix the result is "file:///abs/path"; on Windows, backslashes are
+// normalised and the drive letter is preserved: "file:///C:/Users/...".
+// Relative paths are returned unchanged.
+func FileURI(path string) string {
+	cleaned := strings.ReplaceAll(filepath.Clean(path), "\\", "/")
+	if strings.HasPrefix(cleaned, "/") || (len(cleaned) >= 2 && cleaned[1] == ':') {
+		return "file:///" + strings.TrimPrefix(cleaned, "/")
+	}
+	return cleaned
 }
 
 // schemePrefix matches a leading "<scheme>://" per RFC 3986 scheme syntax.

--- a/fetcher/uri.go
+++ b/fetcher/uri.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -28,18 +27,6 @@ type URI struct {
 	Client *http.Client
 }
 
-// FileURI converts an OS-native absolute path to a valid RFC 8089 file:/// URI.
-// On Unix the result is "file:///abs/path"; on Windows, backslashes are
-// normalised and the drive letter is preserved: "file:///C:/Users/...".
-// Relative paths are returned unchanged.
-func FileURI(path string) string {
-	cleaned := strings.ReplaceAll(filepath.Clean(path), "\\", "/")
-	if strings.HasPrefix(cleaned, "/") || (len(cleaned) >= 2 && cleaned[1] == ':') {
-		return "file:///" + strings.TrimPrefix(cleaned, "/")
-	}
-	return cleaned
-}
-
 // schemePrefix matches a leading "<scheme>://" per RFC 3986 scheme syntax.
 var schemePrefix = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.\-]*://`)
 
@@ -48,11 +35,11 @@ func (u *URI) Fetch(ctx context.Context, source string) (io.ReadCloser, error) {
 	case strings.HasPrefix(source, "http://"), strings.HasPrefix(source, "https://"):
 		return (&HTTP{Client: u.Client}).Fetch(ctx, source)
 	case strings.HasPrefix(source, "file://"):
-		parsed, err := url.Parse(source)
+		path, err := url.PathUnescape(strings.TrimPrefix(source, "file://"))
 		if err != nil {
 			return nil, fmt.Errorf("invalid file URI %q: %w", source, err)
 		}
-		return (&File{}).Fetch(ctx, parsed.Path)
+		return (&File{}).Fetch(ctx, path)
 	case schemePrefix.MatchString(source):
 		return nil, fmt.Errorf("unsupported URI scheme in %q", source)
 	default:

--- a/fetcher/uri_test.go
+++ b/fetcher/uri_test.go
@@ -21,7 +21,7 @@ func TestURI_FileScheme(t *testing.T) {
 	require.NoError(t, os.WriteFile(p, []byte("ok: true\n"), 0600))
 
 	f := &URI{}
-	rc, err := f.Fetch(context.Background(), "file://"+p)
+	rc, err := f.Fetch(context.Background(), FileURI(p))
 	require.NoError(t, err)
 	defer rc.Close() //nolint:errcheck
 
@@ -88,4 +88,39 @@ func TestURI_TypoScheme(t *testing.T) {
 	_, err := f.Fetch(context.Background(), "htps://example.com/file.yaml")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported URI scheme")
+}
+
+func TestFileURI(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "Unix absolute path",
+			input: "/home/user/data.yaml",
+			want:  "file:///home/user/data.yaml",
+		},
+		{
+			name:  "Windows absolute path",
+			input: `C:\Users\foo\data.yaml`,
+			want:  "file:///C:/Users/foo/data.yaml",
+		},
+		{
+			name:  "Relative path unchanged",
+			input: "data/file.yaml",
+			want:  "data/file.yaml",
+		},
+		{
+			name:  "Dot-relative path unchanged",
+			input: "./data/file.yaml",
+			want:  "data/file.yaml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FileURI(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/fetcher/uri_test.go
+++ b/fetcher/uri_test.go
@@ -21,7 +21,7 @@ func TestURI_FileScheme(t *testing.T) {
 	require.NoError(t, os.WriteFile(p, []byte("ok: true\n"), 0600))
 
 	f := &URI{}
-	rc, err := f.Fetch(context.Background(), FileURI(p))
+	rc, err := f.Fetch(context.Background(), "file://"+p)
 	require.NoError(t, err)
 	defer rc.Close() //nolint:errcheck
 
@@ -88,39 +88,4 @@ func TestURI_TypoScheme(t *testing.T) {
 	_, err := f.Fetch(context.Background(), "htps://example.com/file.yaml")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported URI scheme")
-}
-
-func TestFileURI(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{
-			name:  "Unix absolute path",
-			input: "/home/user/data.yaml",
-			want:  "file:///home/user/data.yaml",
-		},
-		{
-			name:  "Windows absolute path",
-			input: `C:\Users\foo\data.yaml`,
-			want:  "file:///C:/Users/foo/data.yaml",
-		},
-		{
-			name:  "Relative path unchanged",
-			input: "data/file.yaml",
-			want:  "data/file.yaml",
-		},
-		{
-			name:  "Dot-relative path unchanged",
-			input: "./data/file.yaml",
-			want:  "data/file.yaml",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := FileURI(tt.input)
-			assert.Equal(t, tt.want, got)
-		})
-	}
 }

--- a/gemaraconv/markdown/render.go
+++ b/gemaraconv/markdown/render.go
@@ -59,6 +59,7 @@ func CatalogToMarkdown(ctx context.Context, catalog gemara.ControlCatalog, cfg C
 	}
 
 	text := collapseExtraNewlines(buf.String())
+	text = strings.ReplaceAll(text, "\r\n", "\n")
 	out := []byte(text)
 	if lineEnding != "\n" {
 		out = []byte(strings.ReplaceAll(string(out), "\n", lineEnding))

--- a/loaders.go
+++ b/loaders.go
@@ -46,7 +46,11 @@ func Load[T any](ctx context.Context, f Fetcher, source string) (*T, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid source %q: %w", source, err)
 	}
-	ext := path.Ext(u.Path)
+	p := u.Path
+	if p == "" {
+		p = source
+	}
+	ext := path.Ext(p)
 	switch ext {
 	case ".yaml", ".yml", ".json":
 	default:


### PR DESCRIPTION
url.Parse interprets Windows drive letters (C:) as host:port, breaking file:// URIs on Windows. Strip the prefix and unescape instead -- this handles both well-formed (file:///path) and common (file://path) inputs without requiring callers to construct RFC 8089 URIs.

Related https://github.com/ossf/security-baseline/issues/505