### PR TITLE
chore: update CODEOWNERS to change maintainers to approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gemaraproj/gemara-maintainers
+* @gemaraproj/go-gemara-approvers


### PR DESCRIPTION
## Approver Nomination: @jmeridth

  Per the [Contributor Ladder](https://github.com/gemaraproj/.github/blob/main/CONTRIBUTOR_LADDER.md), I am nominating @jmeridth as an Approver for `go-gemara`.

  ### Eligibility

  - **Org membership:** Active member of `gemaraproj`
  - **Tenure:** Contributing since March 2025 (~15 months)
  - **Contributions:** 37 issues/PRs across `go-gemara` and `gemara`, including CI, infrastructure, and feature work

  ### Changes

  - Creates the `@gemaraproj/go-gemara-approvers` team
  - Replaces `@gemaraproj/gemara-maintainers` with `@gemaraproj/go-gemara-approvers` in CODEOWNERS
    - Maintainers retain full access via admin role; this shifts day-to-day review routing to the approvers team
