### PR TITLE
feat(bundle): add cross-document mapping-reference validation

### DIFF
--- a/bundle/assemble.go
+++ b/bundle/assemble.go
@@ -27,11 +27,12 @@ func NewAssembler(f gemara.Fetcher) *Assembler {
 // parsedFile pairs a bundle File with its parsed outbound reference data.
 type parsedFile struct {
 	File
-	id      string
-	version string
-	artType gemara.ArtifactType
-	refIDs  []string
-	refURLs map[string]string
+	id          string
+	version     string
+	artType     gemara.ArtifactType
+	refIDs      []string
+	refURLs     map[string]string
+	mappingRefs []gemara.MappingReference
 }
 
 // parseFile decodes a Gemara YAML file into either a gemara.Catalog
@@ -53,6 +54,7 @@ func parseFile(f File) (*parsedFile, error) {
 		pf.id = pol.Metadata.Id
 		pf.version = pol.Metadata.Version
 		pf.artType = pol.Metadata.Type
+		pf.mappingRefs = pol.Metadata.MappingReferences
 		pf.refURLs = mappingRefURLs(pol.Metadata.MappingReferences)
 		pf.refIDs = policyRefIDs(pol.Imports)
 	default:
@@ -63,6 +65,7 @@ func parseFile(f File) (*parsedFile, error) {
 		pf.id = cat.Metadata.Id
 		pf.version = cat.Metadata.Version
 		pf.artType = cat.Metadata.Type
+		pf.mappingRefs = cat.Metadata.MappingReferences
 		pf.refURLs = mappingRefURLs(cat.Metadata.MappingReferences)
 		pf.refIDs = catalogRefIDs(cat.Extends, cat.Imports)
 	}
@@ -126,12 +129,17 @@ func (a *Assembler) Assemble(ctx context.Context, m Manifest, source File) (*Bun
 		imports = append(imports, pf.File)
 	}
 
+	allParsed := make([]*parsedFile, 0, 1+len(importParsed))
+	allParsed = append(allParsed, sourceParsed)
+	allParsed = append(allParsed, importParsed...)
+
 	m.Artifacts = buildArtifactTree(sourceParsed, importParsed, depMap)
 
 	return &Bundle{
 		Manifest: m,
 		Source:   source,
 		Imports:  imports,
+		Warnings: validateMappingRefs(allParsed),
 	}, nil
 }
 
@@ -251,4 +259,40 @@ func importFileName(refID, rawURL string) string {
 		}
 	}
 	return refID + ".yaml"
+}
+
+// String formats the warning as a human-readable diagnostic message.
+func (w MappingWarning) String() string {
+	return fmt.Sprintf(
+		"%s (artifact %q): mapping-reference %q does not match any artifact metadata.id in the set",
+		w.File, w.ArtifactID, w.ReferenceID,
+	)
+}
+
+// validateMappingRefs checks that every URL-less mapping-reference id in
+// each artifact matches at least one metadata.id in the full set.
+func validateMappingRefs(parsed []*parsedFile) []MappingWarning {
+	knownIDs := make(map[string]bool, len(parsed))
+	for _, pf := range parsed {
+		if pf.id != "" {
+			knownIDs[pf.id] = true
+		}
+	}
+
+	var warnings []MappingWarning
+	for _, pf := range parsed {
+		for _, ref := range pf.mappingRefs {
+			if ref.Url != "" {
+				continue
+			}
+			if !knownIDs[ref.Id] {
+				warnings = append(warnings, MappingWarning{
+					File:        pf.Name,
+					ArtifactID:  pf.id,
+					ReferenceID: ref.Id,
+				})
+			}
+		}
+	}
+	return warnings
 }

--- a/bundle/assemble_test.go
+++ b/bundle/assemble_test.go
@@ -457,3 +457,135 @@ func artifactsByName(b *Bundle) map[string]Artifact {
 	}
 	return m
 }
+
+func TestAssemble_MappingWarnings(t *testing.T) {
+	tests := []struct {
+		name         string
+		fetcher      mapFetcher
+		source       File
+		wantWarnings []MappingWarning
+	}{
+		{
+			name:    "url-less ref matching a known metadata.id produces no warning",
+			fetcher: mapFetcher{},
+			source: File{
+				Name: "cat.yaml",
+				Data: mustMarshal(t, testControlCatalog("self-ref",
+					[]gemara.MappingReference{{Id: "self-ref", Title: "Self", Version: "1.0"}},
+					nil, nil,
+				)),
+			},
+		},
+		{
+			name:    "url-less ref not matching any metadata.id produces a warning",
+			fetcher: mapFetcher{},
+			source: File{
+				Name: "cat.yaml",
+				Data: mustMarshal(t, testControlCatalog("my-cat",
+					[]gemara.MappingReference{{Id: "unknown-ref", Title: "Unknown", Version: "1.0"}},
+					nil, nil,
+				)),
+			},
+			wantWarnings: []MappingWarning{
+				{File: "cat.yaml", ArtifactID: "my-cat", ReferenceID: "unknown-ref"},
+			},
+		},
+		{
+			name:    "ref with URL is not validated against metadata.ids",
+			fetcher: mapFetcher{},
+			source: File{
+				Name: "cat.yaml",
+				Data: mustMarshal(t, testControlCatalog("my-cat",
+					[]gemara.MappingReference{{Id: "remote", Title: "Remote", Version: "1.0", Url: "https://example.com/remote.yaml"}},
+					nil, nil,
+				)),
+			},
+		},
+		{
+			name: "multiple warnings across source and imports",
+			fetcher: mapFetcher{
+				"https://example.com/controls.yaml": mustMarshal(t, testControlCatalog("imported-cat",
+					[]gemara.MappingReference{{Id: "phantom-import", Title: "Phantom Import", Version: "1.0"}},
+					nil, nil,
+				)),
+			},
+			source: File{
+				Name: "policy.yaml",
+				Data: mustMarshal(t, testControlCatalog("my-policy",
+					[]gemara.MappingReference{
+						{Id: "CTRL", Title: "Controls", Version: "1.0", Url: "https://example.com/controls.yaml"},
+						{Id: "phantom-source", Title: "Phantom Source", Version: "1.0"},
+					},
+					nil,
+					[]gemara.MultiEntryMapping{
+						{ReferenceId: "CTRL", Entries: []gemara.ArtifactMapping{{ReferenceId: "C1"}}},
+					},
+				)),
+			},
+			wantWarnings: []MappingWarning{
+				{File: "policy.yaml", ArtifactID: "my-policy", ReferenceID: "phantom-source"},
+				{File: "controls.yaml", ArtifactID: "imported-cat", ReferenceID: "phantom-import"},
+			},
+		},
+		{
+			name:    "mixed URL and non-URL refs warns only for non-URL",
+			fetcher: mapFetcher{},
+			source: File{
+				Name: "catalog.yaml",
+				Data: mustMarshal(t, testControlCatalog("my-cat",
+					[]gemara.MappingReference{
+						{Id: "HAS-URL", Title: "Has URL", Version: "1.0", Url: "https://example.com/x.yaml"},
+						{Id: "NO-URL", Title: "No URL", Version: "1.0"},
+					}, nil, nil,
+				)),
+			},
+			wantWarnings: []MappingWarning{
+				{File: "catalog.yaml", ArtifactID: "my-cat", ReferenceID: "NO-URL"},
+			},
+		},
+		{
+			name: "url-less ref resolved via import metadata.id produces no warning",
+			fetcher: mapFetcher{
+				"https://example.com/guidance.yaml": mustMarshal(t, testGuidanceCatalog("ext-guidance")),
+			},
+			source: File{
+				Name: "cat.yaml",
+				Data: mustMarshal(t, testControlCatalog("my-cat",
+					[]gemara.MappingReference{
+						{Id: "GUIDE", Title: "Guide", Version: "1.0", Url: "https://example.com/guidance.yaml"},
+						{Id: "ext-guidance", Title: "Ext Guidance Local", Version: "1.0"},
+					},
+					nil,
+					[]gemara.MultiEntryMapping{
+						{ReferenceId: "GUIDE", Entries: []gemara.ArtifactMapping{{ReferenceId: "G1"}}},
+					},
+				)),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asm := NewAssembler(tt.fetcher)
+			b, err := asm.Assemble(context.Background(), Manifest{}, tt.source)
+			require.NoError(t, err)
+			if tt.wantWarnings == nil {
+				assert.Empty(t, b.Warnings)
+			} else {
+				assert.Equal(t, tt.wantWarnings, b.Warnings)
+			}
+		})
+	}
+}
+
+func TestMappingWarning_String(t *testing.T) {
+	w := MappingWarning{
+		File:        "policy.yaml",
+		ArtifactID:  "org-policy",
+		ReferenceID: "missing-ref",
+	}
+	assert.Contains(t, w.String(), "policy.yaml")
+	assert.Contains(t, w.String(), "org-policy")
+	assert.Contains(t, w.String(), "missing-ref")
+}
+

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -75,10 +75,21 @@ type Bundle struct {
 	Source File
 	// Imports are the resolved transitive dependency files.
 	Imports []File
+	// Warnings holds non-fatal issues found during assembly,
+	// such as mapping-reference IDs that don't match any artifact.
+	Warnings []MappingWarning
 	// Etag is the OCI manifest digest used for cache comparison.
 	Etag string
 
 	sizeLimitBytes int64
+}
+
+// MappingWarning describes a mapping-reference whose id does not match
+// any artifact metadata.id in the provided set.
+type MappingWarning struct {
+	File        string
+	ArtifactID  string
+	ReferenceID string
 }
 
 // SizeLimitBytes returns the configured size limit.


### PR DESCRIPTION
## Summary

- Integrate mapping-reference validation into the assembler, reusing `parseFile`'s existing parsing rather than duplicating it
- `parseFile` now captures `mappingRefs` alongside `refIDs`/`refURLs`
- After the full dependency graph is resolved, `validateMappingRefs` checks that every URL-less `mapping-reference.id` matches at least one `metadata.id` in the assembled set
- Results are surfaced via `Bundle.Warnings` for consumers to inspect after assembly

## Context

When a `mapping-reference` has no `url`, its `id` is expected to match a target artifact's `metadata.id` for bundle-local resolution. Currently there is no validation that catches a mismatch — it only surfaces as a resolution failure in downstream consumers like complypack.

This catches authoring errors early — for example, a policy whose `mapping-reference.id` is `"csc"` when the catalog it references has `metadata.id` `"container-security-controls"`.

References with a URL are skipped since they are resolved externally by the assembler (fetch errors are already hard errors).

## Related

- Closes #91
- gemaraproj/gemara#432 — schema documentation for `mapping-reference.id` (merged)
- complytime/complypack#109 — complypack error that motivated upstream validation
- gemaraproj/gemara-publish-action#13 — surface `Bundle.Warnings` in `grc` (follow-up)
- gemaraproj/gemara-publish-action#14 — draft PR for grc warnings (blocked on this PR)

## Test plan

- [x] URL-less ref matching a known `metadata.id` produces no warning
- [x] URL-less ref not matching any `metadata.id` produces a warning
- [x] Ref with URL is not validated against `metadata.id`s
- [x] URL-less ref resolved via import's `metadata.id` produces no warning
- [x] Multiple warnings across source and imports (both produce warnings in one call)
- [x] `MappingWarning.String()` includes file, artifact ID, and reference ID
- [x] Full repository test suite passes (`go test ./...`)