### PR TITLE
feat(bundle): error by default on unmatched mapping-reference IDs

### DIFF
--- a/bundle/assemble.go
+++ b/bundle/assemble.go
@@ -77,7 +77,11 @@ func parseFile(f File) (*parsedFile, error) {
 // its extends and imports via mapping-references URLs, then recursively
 // parses fetched artifacts for their own references until the full
 // dependency tree is resolved.
-func (a *Assembler) Assemble(ctx context.Context, m Manifest, source File) (*Bundle, error) {
+func (a *Assembler) Assemble(ctx context.Context, m Manifest, source File, opts ...AssembleOption) (*Bundle, error) {
+	var aopts assembleOptions
+	for _, o := range opts {
+		o(&aopts)
+	}
 	if source.Name == "" {
 		return nil, fmt.Errorf("source file is required")
 	}
@@ -135,11 +139,16 @@ func (a *Assembler) Assemble(ctx context.Context, m Manifest, source File) (*Bun
 
 	m.Artifacts = buildArtifactTree(sourceParsed, importParsed, depMap)
 
+	warnings := validateMappingRefs(allParsed)
+	if len(warnings) > 0 && !aopts.continueOnError {
+		return nil, mappingRefError(warnings)
+	}
+
 	return &Bundle{
 		Manifest: m,
 		Source:   source,
 		Imports:  imports,
-		Warnings: validateMappingRefs(allParsed),
+		Warnings: warnings,
 	}, nil
 }
 
@@ -259,6 +268,19 @@ func importFileName(refID, rawURL string) string {
 		}
 	}
 	return refID + ".yaml"
+}
+
+// mappingRefError builds a single error summarising all unmatched
+// mapping-reference IDs found during assembly.
+func mappingRefError(warnings []MappingWarning) error {
+	if len(warnings) == 1 {
+		return fmt.Errorf("unmatched mapping-reference: %s", warnings[0])
+	}
+	msg := fmt.Sprintf("%d unmatched mapping-references:", len(warnings))
+	for _, w := range warnings {
+		msg += "\n  - " + w.String()
+	}
+	return fmt.Errorf("%s", msg)
 }
 
 // String formats the warning as a human-readable diagnostic message.

--- a/bundle/assemble.go
+++ b/bundle/assemble.go
@@ -4,6 +4,7 @@ package bundle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -270,17 +271,14 @@ func importFileName(refID, rawURL string) string {
 	return refID + ".yaml"
 }
 
-// mappingRefError builds a single error summarising all unmatched
+// mappingRefError builds a joined error from all unmatched
 // mapping-reference IDs found during assembly.
 func mappingRefError(warnings []MappingWarning) error {
-	if len(warnings) == 1 {
-		return fmt.Errorf("unmatched mapping-reference: %s", warnings[0])
+	errs := make([]error, len(warnings))
+	for i, w := range warnings {
+		errs[i] = fmt.Errorf("unmatched mapping-reference: %s", w)
 	}
-	msg := fmt.Sprintf("%d unmatched mapping-references:", len(warnings))
-	for _, w := range warnings {
-		msg += "\n  - " + w.String()
-	}
-	return fmt.Errorf("%s", msg)
+	return errors.Join(errs...)
 }
 
 // String formats the warning as a human-readable diagnostic message.

--- a/bundle/assemble_test.go
+++ b/bundle/assemble_test.go
@@ -520,7 +520,7 @@ func TestAssemble_MappingRefErrorByDefault(t *testing.T) {
 					},
 				)),
 			},
-			wantErr: "2 unmatched mapping-references",
+			wantErr: "unmatched mapping-reference",
 		},
 		{
 			name:    "mixed URL and non-URL refs errors only for non-URL",

--- a/bundle/assemble_test.go
+++ b/bundle/assemble_test.go
@@ -255,7 +255,7 @@ func TestAssembler_Assemble(t *testing.T) {
 			asm := NewAssembler(tt.fetcher)
 			m := Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"}
 
-			b, err := asm.Assemble(context.Background(), m, tt.source)
+			b, err := asm.Assemble(context.Background(), m, tt.source, WithContinueOnError())
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
@@ -458,15 +458,15 @@ func artifactsByName(b *Bundle) map[string]Artifact {
 	return m
 }
 
-func TestAssemble_MappingWarnings(t *testing.T) {
+func TestAssemble_MappingRefErrorByDefault(t *testing.T) {
 	tests := []struct {
-		name         string
-		fetcher      mapFetcher
-		source       File
-		wantWarnings []MappingWarning
+		name    string
+		fetcher mapFetcher
+		source  File
+		wantErr string
 	}{
 		{
-			name:    "url-less ref matching a known metadata.id produces no warning",
+			name:    "url-less ref matching a known metadata.id succeeds",
 			fetcher: mapFetcher{},
 			source: File{
 				Name: "cat.yaml",
@@ -477,7 +477,7 @@ func TestAssemble_MappingWarnings(t *testing.T) {
 			},
 		},
 		{
-			name:    "url-less ref not matching any metadata.id produces a warning",
+			name:    "url-less ref not matching any metadata.id returns error",
 			fetcher: mapFetcher{},
 			source: File{
 				Name: "cat.yaml",
@@ -486,9 +486,7 @@ func TestAssemble_MappingWarnings(t *testing.T) {
 					nil, nil,
 				)),
 			},
-			wantWarnings: []MappingWarning{
-				{File: "cat.yaml", ArtifactID: "my-cat", ReferenceID: "unknown-ref"},
-			},
+			wantErr: "unmatched mapping-reference",
 		},
 		{
 			name:    "ref with URL is not validated against metadata.ids",
@@ -499,6 +497,100 @@ func TestAssemble_MappingWarnings(t *testing.T) {
 					[]gemara.MappingReference{{Id: "remote", Title: "Remote", Version: "1.0", Url: "https://example.com/remote.yaml"}},
 					nil, nil,
 				)),
+			},
+		},
+		{
+			name: "multiple mismatches across source and imports returns error",
+			fetcher: mapFetcher{
+				"https://example.com/controls.yaml": mustMarshal(t, testControlCatalog("imported-cat",
+					[]gemara.MappingReference{{Id: "phantom-import", Title: "Phantom Import", Version: "1.0"}},
+					nil, nil,
+				)),
+			},
+			source: File{
+				Name: "policy.yaml",
+				Data: mustMarshal(t, testControlCatalog("my-policy",
+					[]gemara.MappingReference{
+						{Id: "CTRL", Title: "Controls", Version: "1.0", Url: "https://example.com/controls.yaml"},
+						{Id: "phantom-source", Title: "Phantom Source", Version: "1.0"},
+					},
+					nil,
+					[]gemara.MultiEntryMapping{
+						{ReferenceId: "CTRL", Entries: []gemara.ArtifactMapping{{ReferenceId: "C1"}}},
+					},
+				)),
+			},
+			wantErr: "2 unmatched mapping-references",
+		},
+		{
+			name:    "mixed URL and non-URL refs errors only for non-URL",
+			fetcher: mapFetcher{},
+			source: File{
+				Name: "catalog.yaml",
+				Data: mustMarshal(t, testControlCatalog("my-cat",
+					[]gemara.MappingReference{
+						{Id: "HAS-URL", Title: "Has URL", Version: "1.0", Url: "https://example.com/x.yaml"},
+						{Id: "NO-URL", Title: "No URL", Version: "1.0"},
+					}, nil, nil,
+				)),
+			},
+			wantErr: "unmatched mapping-reference",
+		},
+		{
+			name: "url-less ref resolved via import metadata.id succeeds",
+			fetcher: mapFetcher{
+				"https://example.com/guidance.yaml": mustMarshal(t, testGuidanceCatalog("ext-guidance")),
+			},
+			source: File{
+				Name: "cat.yaml",
+				Data: mustMarshal(t, testControlCatalog("my-cat",
+					[]gemara.MappingReference{
+						{Id: "GUIDE", Title: "Guide", Version: "1.0", Url: "https://example.com/guidance.yaml"},
+						{Id: "ext-guidance", Title: "Ext Guidance Local", Version: "1.0"},
+					},
+					nil,
+					[]gemara.MultiEntryMapping{
+						{ReferenceId: "GUIDE", Entries: []gemara.ArtifactMapping{{ReferenceId: "G1"}}},
+					},
+				)),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asm := NewAssembler(tt.fetcher)
+			b, err := asm.Assemble(context.Background(), Manifest{}, tt.source)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				assert.Nil(t, b)
+				return
+			}
+			require.NoError(t, err)
+			assert.Empty(t, b.Warnings)
+		})
+	}
+}
+
+func TestAssemble_MappingWarningsWithContinueOnError(t *testing.T) {
+	tests := []struct {
+		name         string
+		fetcher      mapFetcher
+		source       File
+		wantWarnings []MappingWarning
+	}{
+		{
+			name:    "url-less ref not matching any metadata.id produces warning",
+			fetcher: mapFetcher{},
+			source: File{
+				Name: "cat.yaml",
+				Data: mustMarshal(t, testControlCatalog("my-cat",
+					[]gemara.MappingReference{{Id: "unknown-ref", Title: "Unknown", Version: "1.0"}},
+					nil, nil,
+				)),
+			},
+			wantWarnings: []MappingWarning{
+				{File: "cat.yaml", ArtifactID: "my-cat", ReferenceID: "unknown-ref"},
 			},
 		},
 		{
@@ -528,37 +620,13 @@ func TestAssemble_MappingWarnings(t *testing.T) {
 			},
 		},
 		{
-			name:    "mixed URL and non-URL refs warns only for non-URL",
+			name:    "matching ref produces no warning with continue-on-error",
 			fetcher: mapFetcher{},
 			source: File{
-				Name: "catalog.yaml",
-				Data: mustMarshal(t, testControlCatalog("my-cat",
-					[]gemara.MappingReference{
-						{Id: "HAS-URL", Title: "Has URL", Version: "1.0", Url: "https://example.com/x.yaml"},
-						{Id: "NO-URL", Title: "No URL", Version: "1.0"},
-					}, nil, nil,
-				)),
-			},
-			wantWarnings: []MappingWarning{
-				{File: "catalog.yaml", ArtifactID: "my-cat", ReferenceID: "NO-URL"},
-			},
-		},
-		{
-			name: "url-less ref resolved via import metadata.id produces no warning",
-			fetcher: mapFetcher{
-				"https://example.com/guidance.yaml": mustMarshal(t, testGuidanceCatalog("ext-guidance")),
-			},
-			source: File{
 				Name: "cat.yaml",
-				Data: mustMarshal(t, testControlCatalog("my-cat",
-					[]gemara.MappingReference{
-						{Id: "GUIDE", Title: "Guide", Version: "1.0", Url: "https://example.com/guidance.yaml"},
-						{Id: "ext-guidance", Title: "Ext Guidance Local", Version: "1.0"},
-					},
-					nil,
-					[]gemara.MultiEntryMapping{
-						{ReferenceId: "GUIDE", Entries: []gemara.ArtifactMapping{{ReferenceId: "G1"}}},
-					},
+				Data: mustMarshal(t, testControlCatalog("self-ref",
+					[]gemara.MappingReference{{Id: "self-ref", Title: "Self", Version: "1.0"}},
+					nil, nil,
 				)),
 			},
 		},
@@ -567,7 +635,7 @@ func TestAssemble_MappingWarnings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			asm := NewAssembler(tt.fetcher)
-			b, err := asm.Assemble(context.Background(), Manifest{}, tt.source)
+			b, err := asm.Assemble(context.Background(), Manifest{}, tt.source, WithContinueOnError())
 			require.NoError(t, err)
 			if tt.wantWarnings == nil {
 				assert.Empty(t, b.Warnings)

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -111,6 +111,22 @@ func (b *Bundle) Version() string {
 	return b.Manifest.BundleVersion
 }
 
+// AssembleOption configures Assemble behaviour.
+type AssembleOption func(*assembleOptions)
+
+type assembleOptions struct {
+	continueOnError bool
+}
+
+// WithContinueOnError makes Assemble populate Bundle.Warnings instead of
+// returning an error when mapping-reference IDs don't match any artifact
+// metadata.id in the assembled set.
+func WithContinueOnError() AssembleOption {
+	return func(o *assembleOptions) {
+		o.continueOnError = true
+	}
+}
+
 // PackOption configures Pack behaviour.
 type PackOption func(*packOptions)
 


### PR DESCRIPTION
## Summary

- `Assemble` now returns an error when URL-less `mapping-reference.id` values don't match any `metadata.id` in the assembled set (previously populated `Bundle.Warnings`)
- New `AssembleOption`: `WithContinueOnError()` preserves the previous warning behavior for callers that need it
- Existing tests split into error-by-default and continue-on-error test suites

## Breaking change

Bundles with unmatched mapping-reference IDs that previously assembled successfully (with warnings) will now return an error. Downstream consumers need to either:
- Fix their mapping-reference IDs, or
- Pass `WithContinueOnError()` to opt into lenient mode

## Context

Discussed in the [PR #92 review](https://github.com/gemaraproj/go-gemara/pull/92#issuecomment-4920300904) — @jpower432 suggested the assembler should error by default with a continue-on-error option.

## Related

- Closes #97
- #92 — added `Bundle.Warnings` with mapping-reference validation (merged)
- #91 — original cross-document validation issue
- gemaraproj/gemara-publish-action#14 — surfaces `Bundle.Warnings` in `grc` (will need `WithContinueOnError()` or to let errors propagate)

## Test plan

- [x] URL-less ref not matching any `metadata.id` returns error by default
- [x] Multiple mismatches return error listing all unmatched refs
- [x] URL-less ref matching a known `metadata.id` succeeds
- [x] Ref with URL is not validated
- [x] `WithContinueOnError()` populates `Bundle.Warnings` instead of erroring
- [x] Full repository test suite passes (`go test ./...`)