### PR TITLE
feat!: require Fetcher for lexicon autolink in CatalogToMarkdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ func main() {
 }
 ```
 
+### Fetching Remote Artifacts
+
+The `fetcher.HTTP` and `fetcher.URI` types follow any URL without filtering,
+including private network addresses. Applications that process untrusted
+URLs should supply an `http.Client` with a safe dialer — see
+[`ExampleURI_ssrfSafe`](fetcher/example_test.go) for a complete example
+that blocks private, loopback, and link-local addresses at connect time.
+
 ## Development
 
 ### Building

--- a/gemaraconv/catalog_markdown.go
+++ b/gemaraconv/catalog_markdown.go
@@ -21,8 +21,9 @@ func CatalogToMarkdown(ctx context.Context, catalog gemara.ControlCatalog, opts 
 		LineEnding:          o.lineEnding,
 		Metadata:            o.metadata,
 		ApplicabilityMatrix: o.applicabilityMatrix,
-		LexiconAutolink:     o.lexiconAutolink,
+		LexiconAutolink:     o.fetcher != nil,
 		InlineLexicon:       o.inlineLexicon,
+		Fetcher:             o.fetcher,
 	}
 	return markdown.CatalogToMarkdown(ctx, catalog, cfg)
 }

--- a/gemaraconv/doc.go
+++ b/gemaraconv/doc.go
@@ -12,7 +12,7 @@
 //
 //	sarifBytes, err := gemaraconv.ToSARIF(log, gemaraconv.WithArtifactURI("file.md"), gemaraconv.WithCatalog(catalog))
 //	oscalCatalog, err := gemaraconv.CatalogToOSCAL(catalog, gemaraconv.WithVersion("1.0"))
-//	md, err := gemaraconv.CatalogToMarkdown(ctx, catalog, gemaraconv.WithTOC(true), gemaraconv.WithLexiconAutolink(true))
+//	md, err := gemaraconv.CatalogToMarkdown(ctx, catalog, gemaraconv.WithTOC(true), gemaraconv.WithLexiconAutolink(&fetcher.URI{}))
 //	// Or pass list-shaped entries: WithInlineLexicon([]gemaraconv.InlineLexiconTerm{...})
 //	converter := gemaraconv.EvaluationLog(log)
 //	sarifBytes, err := converter.ToSARIF(gemaraconv.WithArtifactURI("file.md"), gemaraconv.WithCatalog(catalog))

--- a/gemaraconv/markdown/config.go
+++ b/gemaraconv/markdown/config.go
@@ -1,5 +1,7 @@
 package markdown
 
+import "github.com/gemaraproj/go-gemara"
+
 // Config holds Markdown rendering options for CatalogToMarkdown.
 type Config struct {
 	TOC                 bool
@@ -8,4 +10,5 @@ type Config struct {
 	ApplicabilityMatrix bool
 	LexiconAutolink     bool
 	InlineLexicon       []InlineLexiconTerm
+	Fetcher             gemara.Fetcher
 }

--- a/gemaraconv/markdown/lexicon_load.go
+++ b/gemaraconv/markdown/lexicon_load.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/gemaraproj/go-gemara"
-	"github.com/gemaraproj/go-gemara/fetcher"
 	"github.com/gemaraproj/go-gemara/internal/codec"
 )
 
@@ -39,8 +38,8 @@ func resolveLexiconURL(meta gemara.Metadata) (string, error) {
 
 // loadLexiconFromURI fetches a Lexicon from an http(s):// URL, a file:// URI,
 // or a local file path, and returns normalized entries.
-func loadLexiconFromURI(ctx context.Context, uri string) ([]lexiconEntry, error) {
-	doc, err := gemara.Load[gemara.Lexicon](ctx, &fetcher.URI{}, uri)
+func loadLexiconFromURI(ctx context.Context, f gemara.Fetcher, uri string) ([]lexiconEntry, error) {
+	doc, err := gemara.Load[gemara.Lexicon](ctx, f, uri)
 	if err != nil {
 		return nil, fmt.Errorf("load lexicon: %w", err)
 	}

--- a/gemaraconv/markdown/lexicon_load_test.go
+++ b/gemaraconv/markdown/lexicon_load_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
+	"github.com/gemaraproj/go-gemara/fetcher"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,7 +40,7 @@ func TestParseLexiconYAML_rejects(t *testing.T) {
 }
 
 func TestLoadLexiconFromURI_file(t *testing.T) {
-	entries, err := loadLexiconFromURI(context.Background(), lexiconTestdataAbsPath(t, "lexicon_good.yaml"))
+	entries, err := loadLexiconFromURI(context.Background(), &fetcher.URI{}, lexiconTestdataAbsPath(t, "lexicon_good.yaml"))
 	require.NoError(t, err)
 	require.Len(t, entries, 2)
 }
@@ -88,7 +89,7 @@ func TestLexiconGistIntegration(t *testing.T) {
 		t.Skip("network")
 	}
 	const gist = "https://gist.githubusercontent.com/eddie-knight/3ffa5e1a5d562ba0f3b0cd3f5b563679/raw/1b39cb516f23430288b7893004eb0b91f14a7487/lexicon.yaml"
-	entries, err := loadLexiconFromURI(context.Background(), gist)
+	entries, err := loadLexiconFromURI(context.Background(), &fetcher.URI{}, gist)
 	require.NoError(t, err)
 	require.NotEmpty(t, entries)
 }

--- a/gemaraconv/markdown/render.go
+++ b/gemaraconv/markdown/render.go
@@ -27,11 +27,14 @@ func CatalogToMarkdown(ctx context.Context, catalog gemara.ControlCatalog, cfg C
 	var lexEntries []lexiconEntry
 	switch {
 	case cfg.LexiconAutolink && catalog.Metadata.Lexicon != nil:
+		if cfg.Fetcher == nil {
+			return nil, fmt.Errorf("lexicon autolink requires a non-nil Fetcher")
+		}
 		lexiconURI, err := resolveLexiconURL(catalog.Metadata)
 		if err != nil {
 			return nil, fmt.Errorf("lexicon: resolve URL: %w", err)
 		}
-		loaded, err := loadLexiconFromURI(ctx, lexiconURI)
+		loaded, err := loadLexiconFromURI(ctx, cfg.Fetcher, lexiconURI)
 		if err != nil {
 			return nil, fmt.Errorf("lexicon: %w", err)
 		}

--- a/gemaraconv/markdown/render_test.go
+++ b/gemaraconv/markdown/render_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
+	"github.com/gemaraproj/go-gemara/fetcher"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -272,7 +273,7 @@ func TestCatalogToMarkdown_lexiconAutolinkFromFile(t *testing.T) {
 			{Id: "C", Group: "G", Title: "Example Term in title", Objective: "text", State: gemara.LifecycleActive},
 		},
 	}
-	out, err := CatalogToMarkdown(context.Background(), catalog, Config{TOC: false, LexiconAutolink: true})
+	out, err := CatalogToMarkdown(context.Background(), catalog, Config{TOC: false, LexiconAutolink: true, Fetcher: &fetcher.URI{}})
 	require.NoError(t, err)
 	assert.Contains(t, string(out), "## Lexicon")
 }
@@ -287,9 +288,27 @@ func TestCatalogToMarkdown_lexiconResolveError(t *testing.T) {
 		Groups:   []gemara.Group{{Id: "G", Title: "G"}},
 		Controls: []gemara.Control{{Id: "C", Group: "G", Title: "T", Objective: "o", State: gemara.LifecycleActive}},
 	}
-	_, err := CatalogToMarkdown(context.Background(), catalog, Config{LexiconAutolink: true})
+	_, err := CatalogToMarkdown(context.Background(), catalog, Config{LexiconAutolink: true, Fetcher: &fetcher.URI{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "lexicon")
+}
+
+func TestCatalogToMarkdown_lexiconAutolink_nilFetcher(t *testing.T) {
+	catalog := gemara.ControlCatalog{
+		Metadata: gemara.Metadata{
+			Id: "m", Type: gemara.ControlCatalogArtifact, Description: "d", Author: gemara.Actor{Name: "a", Type: gemara.Human},
+			Lexicon: &gemara.ArtifactMapping{ReferenceId: "lex"},
+			MappingReferences: []gemara.MappingReference{
+				{Id: "lex", Title: "L", Version: "1", Url: lexiconTestdataAbsPath(t, "lexicon_good.yaml")},
+			},
+		},
+		Title:    "x",
+		Groups:   []gemara.Group{{Id: "G", Title: "G"}},
+		Controls: []gemara.Control{{Id: "C", Group: "G", Title: "T", Objective: "o", State: gemara.LifecycleActive}},
+	}
+	_, err := CatalogToMarkdown(context.Background(), catalog, Config{LexiconAutolink: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-nil Fetcher")
 }
 
 func TestCatalogToMarkdown_inlineLexiconNormalizeError(t *testing.T) {

--- a/gemaraconv/markdown_test.go
+++ b/gemaraconv/markdown_test.go
@@ -362,7 +362,7 @@ func TestCatalogToMarkdown_lexiconAutolink(t *testing.T) {
 		},
 	}
 
-	out, err := CatalogToMarkdown(context.Background(), catalog, WithLexiconAutolink(true), WithTOC(false))
+	out, err := CatalogToMarkdown(context.Background(), catalog, WithLexiconAutolink(&fetcher.URI{}), WithTOC(false))
 	require.NoError(t, err)
 	s := string(out)
 
@@ -436,6 +436,10 @@ func TestCatalogToMarkdown_lexiconAutolink_resolveError(t *testing.T) {
 		Groups:   []gemara.Group{{Id: "G", Title: "G"}},
 		Controls: []gemara.Control{{Id: "C", Group: "G", Title: "T", Objective: "o", State: gemara.LifecycleActive}},
 	}
-	_, err := CatalogToMarkdown(context.Background(), catalog, WithLexiconAutolink(true))
+	_, err := CatalogToMarkdown(context.Background(), catalog, WithLexiconAutolink(&fetcher.URI{}))
 	require.Error(t, err)
+}
+
+func TestWithLexiconAutolink_nilPanics(t *testing.T) {
+	assert.Panics(t, func() { WithLexiconAutolink(nil) })
 }

--- a/gemaraconv/options.go
+++ b/gemaraconv/options.go
@@ -72,8 +72,8 @@ type markdownOpts struct {
 	lineEnding          string
 	metadata            bool
 	applicabilityMatrix bool
-	lexiconAutolink     bool
 	inlineLexicon       []InlineLexiconTerm
+	fetcher             gemara.Fetcher
 }
 
 func defaultMarkdownOpts() markdownOpts {
@@ -122,12 +122,20 @@ func WithApplicabilityMatrix(enabled bool) MarkdownOption {
 	}
 }
 
-// WithLexiconAutolink enables loading metadata.lexicon from mapping-references (or remarks URL),
-// strict Gemara Lexicon YAML, term autolinking in prose, and a trailing glossary (default false).
-// When enabled and metadata.lexicon is set, this takes precedence over WithInlineLexicon.
-func WithLexiconAutolink(enabled bool) MarkdownOption {
+// WithLexiconAutolink enables loading the lexicon referenced in metadata.lexicon
+// (via mapping-references or remarks URL), term autolinking in prose, and a
+// trailing glossary. The provided [gemara.Fetcher] is used to load the lexicon
+// document. When enabled and metadata.lexicon is set, this takes precedence
+// over [WithInlineLexicon].
+//
+// See [fetcher.ExampleURI_ssrfSafe] for an example that blocks requests to
+// private network addresses.
+func WithLexiconAutolink(f gemara.Fetcher) MarkdownOption {
+	if f == nil {
+		panic("WithLexiconAutolink requires a non-nil Fetcher")
+	}
 	return func(o *markdownOpts) {
-		o.lexiconAutolink = enabled
+		o.fetcher = f
 	}
 }
 


### PR DESCRIPTION
## Summary

  - Breaking: WithLexiconAutolink() now takes a `Fetcher`. Previously `loadLexiconFromURI` silently created a bare fetcher.URI{}, ignoring any http.Client the caller configured
  - Thread the caller's Fetcher through Config into loadLexiconFromURI
  - Surface the SSRF-safe dialer example in the README

### Breaking Change

```
  // Before
  md, err := gemaraconv.CatalogToMarkdown(ctx, catalog, gemaraconv.WithLexiconAutolink(true))

  // After
  md, err := gemaraconv.CatalogToMarkdown(ctx, catalog, gemaraconv.WithLexiconAutolink(&fetcher.URI{}))
  ```

 ## Test plan

  - New: LexiconAutolink without Fetcher returns error
  - Updated all existing lexicon autolink tests to provide a Fetcher
  - go test ./... -short passes

Related to #96
