### PR TITLE
fix: handle NotApplicable in UpdateAggregateResult

### DIFF
--- a/enums.go
+++ b/enums.go
@@ -1011,9 +1011,16 @@ func UpdateAggregateResult(previous Result, new Result) Result {
 	}
 
 	if previous == NeedsReview || new == NeedsReview {
-		// NeedsReview should not be overwritten by Passed
-		// NeedsReview should overwrite Passed
+		// NeedsReview should not be overwritten by Passed or NotApplicable
+		// NeedsReview should overwrite Passed and NotApplicable
 		return NeedsReview
 	}
-	return Passed
+
+	if previous == Passed || new == Passed {
+		// Passed should not be overwritten by NotApplicable
+		// Passed should overwrite NotApplicable
+		return Passed
+	}
+
+	return NotApplicable
 }

--- a/enums_test.go
+++ b/enums_test.go
@@ -99,6 +99,72 @@ func TestUpdateAggregateResult(t *testing.T) {
 			new:      NeedsReview,
 			expected: NeedsReview,
 		},
+		{
+			name:     "NotApplicable should overwrite NotRun",
+			prev:     NotRun,
+			new:      NotApplicable,
+			expected: NotApplicable,
+		},
+		{
+			name:     "NotApplicable should not overwrite Passed",
+			prev:     Passed,
+			new:      NotApplicable,
+			expected: Passed,
+		},
+		{
+			name:     "NotApplicable should not overwrite Failed",
+			prev:     Failed,
+			new:      NotApplicable,
+			expected: Failed,
+		},
+		{
+			name:     "NotApplicable should not overwrite Unknown",
+			prev:     Unknown,
+			new:      NotApplicable,
+			expected: Unknown,
+		},
+		{
+			name:     "NotApplicable should not overwrite NeedsReview",
+			prev:     NeedsReview,
+			new:      NotApplicable,
+			expected: NeedsReview,
+		},
+		{
+			name:     "NotApplicable with NotApplicable returns NotApplicable",
+			prev:     NotApplicable,
+			new:      NotApplicable,
+			expected: NotApplicable,
+		},
+		{
+			name:     "Passed should overwrite NotApplicable",
+			prev:     NotApplicable,
+			new:      Passed,
+			expected: Passed,
+		},
+		{
+			name:     "Failed should overwrite NotApplicable",
+			prev:     NotApplicable,
+			new:      Failed,
+			expected: Failed,
+		},
+		{
+			name:     "Unknown should overwrite NotApplicable",
+			prev:     NotApplicable,
+			new:      Unknown,
+			expected: Unknown,
+		},
+		{
+			name:     "NeedsReview should overwrite NotApplicable",
+			prev:     NotApplicable,
+			new:      NeedsReview,
+			expected: NeedsReview,
+		},
+		{
+			name:     "NotRun should not overwrite NotApplicable",
+			prev:     NotApplicable,
+			new:      NotRun,
+			expected: NotApplicable,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
NotApplicable was not checked in UpdateAggregateResult, causing it to
fall through to a default Passed return. This produced incorrect scan
reports when all rules for a control were not applicable.

Add NotApplicable to the severity chain between Passed and NotRun:
Failed > Unknown > NeedsReview > Passed > NotApplicable > NotRun

Closes #103

Assisted-by: Claude Sonnet 4.6
Signed-off-by: Trevor Vaughan <tvaughan@redhat.com>
