### PR TITLE
feat(fetcher): add BasePath to URI for relative file:// resolution

### DIFF
--- a/bundle/assemble_test.go
+++ b/bundle/assemble_test.go
@@ -656,4 +656,3 @@ func TestMappingWarning_String(t *testing.T) {
 	assert.Contains(t, w.String(), "org-policy")
 	assert.Contains(t, w.String(), "missing-ref")
 }
-

--- a/fetcher/uri.go
+++ b/fetcher/uri.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -21,10 +22,20 @@ import (
 //     including Windows drive paths) is treated as a local file path.
 //   - Inputs with any other <scheme>:// prefix return an unsupported-scheme error.
 //
+// When BasePath is set, relative file:// URIs and bare relative paths are
+// resolved against it instead of the process working directory. Absolute
+// paths are unaffected. This lets callers anchor resolution to the source
+// artifact's directory rather than relying on the working directory.
+//
 // For HTTP(S) sources it delegates to [HTTP]; see that type's
 // documentation for security considerations.
 type URI struct {
 	Client *http.Client
+
+	// BasePath is the directory used to resolve relative file:// URIs and
+	// bare relative paths. When empty, paths resolve against the process
+	// working directory (the default, backward-compatible behavior).
+	BasePath string
 }
 
 // schemePrefix matches a leading "<scheme>://" per RFC 3986 scheme syntax.
@@ -39,10 +50,19 @@ func (u *URI) Fetch(ctx context.Context, source string) (io.ReadCloser, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid file URI %q: %w", source, err)
 		}
-		return (&File{}).Fetch(ctx, path)
+		return (&File{}).Fetch(ctx, u.resolveLocal(path))
 	case schemePrefix.MatchString(source):
 		return nil, fmt.Errorf("unsupported URI scheme in %q", source)
 	default:
-		return (&File{}).Fetch(ctx, source)
+		return (&File{}).Fetch(ctx, u.resolveLocal(source))
 	}
+}
+
+// resolveLocal joins path with BasePath when the path is relative and
+// BasePath is set. Absolute paths are returned unchanged.
+func (u *URI) resolveLocal(path string) string {
+	if u.BasePath != "" && !filepath.IsAbs(path) {
+		return filepath.Join(u.BasePath, path)
+	}
+	return path
 }

--- a/fetcher/uri_test.go
+++ b/fetcher/uri_test.go
@@ -89,3 +89,116 @@ func TestURI_TypoScheme(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported URI scheme")
 }
+
+func TestURI_BasePath_FileScheme(t *testing.T) {
+	base := t.TempDir()
+	sub := filepath.Join(base, "catalogs")
+	require.NoError(t, os.MkdirAll(sub, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "c.yaml"), []byte("found: true\n"), 0600))
+
+	tests := []struct {
+		name     string
+		basePath string
+		source   string
+		want     string
+	}{
+		{
+			name:     "relative file:// resolved against BasePath",
+			basePath: base,
+			source:   "file://catalogs/c.yaml",
+			want:     "found: true\n",
+		},
+		{
+			name:     "dot-slash relative file:// resolved against BasePath",
+			basePath: base,
+			source:   "file://./catalogs/c.yaml",
+			want:     "found: true\n",
+		},
+		{
+			name:     "parent-relative file:// resolved against BasePath",
+			basePath: sub,
+			source:   "file://../catalogs/c.yaml",
+			want:     "found: true\n",
+		},
+		{
+			name:     "absolute file:// ignores BasePath",
+			basePath: "/should/not/matter",
+			source:   "file://" + filepath.Join(sub, "c.yaml"),
+			want:     "found: true\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &URI{BasePath: tt.basePath}
+			rc, err := f.Fetch(context.Background(), tt.source)
+			require.NoError(t, err)
+			defer rc.Close() //nolint:errcheck
+
+			data, err := io.ReadAll(rc)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(data))
+		})
+	}
+}
+
+func TestURI_BasePath_BarePath(t *testing.T) {
+	base := t.TempDir()
+	sub := filepath.Join(base, "catalogs")
+	require.NoError(t, os.MkdirAll(sub, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "c.yaml"), []byte("bare: true\n"), 0600))
+
+	tests := []struct {
+		name     string
+		basePath string
+		source   string
+		want     string
+	}{
+		{
+			name:     "bare relative path resolved against BasePath",
+			basePath: base,
+			source:   "catalogs/c.yaml",
+			want:     "bare: true\n",
+		},
+		{
+			name:     "dot-slash bare path resolved against BasePath",
+			basePath: base,
+			source:   "./catalogs/c.yaml",
+			want:     "bare: true\n",
+		},
+		{
+			name:     "absolute bare path ignores BasePath",
+			basePath: "/should/not/matter",
+			source:   filepath.Join(sub, "c.yaml"),
+			want:     "bare: true\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &URI{BasePath: tt.basePath}
+			rc, err := f.Fetch(context.Background(), tt.source)
+			require.NoError(t, err)
+			defer rc.Close() //nolint:errcheck
+
+			data, err := io.ReadAll(rc)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(data))
+		})
+	}
+}
+
+func TestURI_BasePath_Empty_BackwardCompatible(t *testing.T) {
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "data.yaml"), []byte("compat: true\n"), 0600))
+	t.Chdir(tmp)
+
+	f := &URI{}
+	rc, err := f.Fetch(context.Background(), "file://./data.yaml")
+	require.NoError(t, err)
+	defer rc.Close() //nolint:errcheck
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "compat: true\n", string(data))
+}


### PR DESCRIPTION
## Summary

- Add a `BasePath` field to `fetcher.URI` so relative `file://` URIs and bare relative paths resolve against a caller-specified directory instead of the process working directory (`os.Getwd()`)
- When `BasePath` is empty (the zero value), behavior is unchanged — paths still resolve against `os.Getwd()`, preserving full backward compatibility
- New `resolveLocal` helper joins relative paths with `BasePath` using `filepath.Join`; both the `file://` branch and the bare-path `default` branch use it
- Absolute paths are unaffected regardless of `BasePath`

## Context

The `complytime-policies` publish workflow broke when `file://` prefixes were added to `mapping-references` URLs (complytime/complytime-policies#48). The `grc` CLI in `gemara-publish-action` uses `&fetcher.File{}`, which calls `os.Open(source)` on the raw URL string — no `file://` scheme support at all. The go-gemara bump in gemara-publish-action#12 (v0.4.0 → v0.7.0) fixed `fetcher.URI` but didn't help because `grc` never uses `URI`.

The minimal fix is switching `grc` from `&fetcher.File{}` to `&fetcher.URI{}` while keeping the existing `cd "$ROOT_DIR"` workaround in `action.yml`. This PR goes further by adding `BasePath` so the resolution directory is explicit in code — making it concurrency-safe and removing the need for the shell workaround.

### Why not omit `url` instead?

An alternative explored in gemara-mcp#101 and gemara-ai#11 was to guide users to omit `url` for bundle-local mapping-references, assuming the assembler resolves by `metadata.id` matching. In practice, ID matching (`validateMappingRefs`) is validation only — the assembler needs a URL in `enqueueRefs` to fetch the dependency into the bundle. Without a URL, the dep is silently skipped, producing an incomplete bundle. URL-less (runtime) resolution is a separate design concern tracked in #75.

### Transitive dependencies

When used with `bundle.Assembler`, all levels of the dependency graph resolve against the single `BasePath`. The assembler only follows references listed in top-level `extends` and `imports` (via `catalogRefIDs`/`policyRefIDs`). Per-control inline `reference-id` entries are not followed as fetch targets — catalogs and guidance that carry `mapping-references` with `file://` URLs do not have top-level `imports` that would trigger transitive fetches.

If a future artifact structure introduces multi-level relative `file://` imports, the assembler can resolve each dependency's URLs against that dependency's directory by rewriting URLs in the fetch loop — no API changes required.

## Related

- Closes #93
- complytime/complytime-policies#48 — added `file://` prefixes (correct for bundle completeness, but exposed the `grc` fetcher bug)
- gemaraproj/gemara-publish-action#12 — go-gemara bump (v0.4.0 → v0.7.0)
- **Follow-up**: gemara-publish-action — switch `grc` from `&fetcher.File{}` to `&fetcher.URI{BasePath: ...}` and remove the `cd "$ROOT_DIR"` workaround
- **Follow-up**: gemaraproj/gemara-ai#11 — needs rework: "omit url" guidance produces incomplete bundles; correct guidance is to use relative `file://` URLs

## Test plan

- [x] `go test ./... -short` passes (all packages)
- [x] Relative `file://` URI resolved against `BasePath`
- [x] Dot-slash (`./`) and parent-relative (`../`) `file://` URIs resolved against `BasePath`
- [x] Absolute `file://` URI ignores `BasePath`
- [x] Bare relative path resolved against `BasePath`
- [x] Dot-slash bare path resolved against `BasePath`
- [x] Absolute bare path ignores `BasePath`
- [x] Empty `BasePath` preserves cwd resolution (backward compatible)
- [x] All existing tests pass unchanged