### PR TITLE
Evaluate all applicable sub-requirements after failures

### DIFF
--- a/control_evaluation.go
+++ b/control_evaluation.go
@@ -15,6 +15,9 @@ func (c *ControlEvaluation) AddAssessment(requirementId string, description stri
 // Every applicable assessment (sub-requirement) is evaluated independently; a failing sub-requirement
 // must not suppress evaluation of its siblings. The control's aggregate result is accumulated via
 // UpdateAggregateResult, so an earlier Failed still wins the rollup without skipping later assessments.
+// Message retains the first assessment message that establishes the aggregate result's current severity;
+// tied results do not replace it. Each assessment's own result and message remain in AssessmentLogs so
+// consumers can report every condition rather than relying only on the control-level summary.
 // Consequently, a later sibling's steps may produce side effects after an earlier assessment fails;
 // each assessment retains its own step-level fail-fast behavior.
 // The targetData is the data that the assessment will be run against. The userApplicability is a slice
@@ -37,7 +40,7 @@ func (c *ControlEvaluation) Evaluate(targetData interface{}, userApplicability [
 		if applicable {
 			result := assessment.Run(targetData)
 			aggregateResult := UpdateAggregateResult(c.Result, result)
-			if result == aggregateResult {
+			if aggregateResult != c.Result {
 				c.Message = assessment.Message
 			}
 			c.Result = aggregateResult

--- a/control_evaluation.go
+++ b/control_evaluation.go
@@ -15,6 +15,8 @@ func (c *ControlEvaluation) AddAssessment(requirementId string, description stri
 // Every applicable assessment (sub-requirement) is evaluated independently; a failing sub-requirement
 // must not suppress evaluation of its siblings. The control's aggregate result is accumulated via
 // UpdateAggregateResult, so an earlier Failed still wins the rollup without skipping later assessments.
+// Consequently, a later sibling's steps may produce side effects after an earlier assessment fails;
+// each assessment retains its own step-level fail-fast behavior.
 // The targetData is the data that the assessment will be run against. The userApplicability is a slice
 // of strings that determine when the assessment is applicable.
 func (c *ControlEvaluation) Evaluate(targetData interface{}, userApplicability []string) {
@@ -34,8 +36,11 @@ func (c *ControlEvaluation) Evaluate(targetData interface{}, userApplicability [
 		}
 		if applicable {
 			result := assessment.Run(targetData)
-			c.Result = UpdateAggregateResult(c.Result, result)
-			c.Message = assessment.Message
+			aggregateResult := UpdateAggregateResult(c.Result, result)
+			if result == aggregateResult {
+				c.Message = assessment.Message
+			}
+			c.Result = aggregateResult
 		}
 	}
 }

--- a/control_evaluation.go
+++ b/control_evaluation.go
@@ -12,9 +12,11 @@ func (c *ControlEvaluation) AddAssessment(requirementId string, description stri
 }
 
 // Evaluate runs each step in each assessment, updating the relevant fields on the control evaluation.
-// It will halt if a step returns a failed result. The targetData is the data that the assessment will be run against.
-// The userApplicability is a slice of strings that determine when the assessment is applicable. The changesAllowed
-// determines whether the assessment is allowed to execute its changes.
+// Every applicable assessment (sub-requirement) is evaluated independently; a failing sub-requirement
+// must not suppress evaluation of its siblings. The control's aggregate result is accumulated via
+// UpdateAggregateResult, so an earlier Failed still wins the rollup without skipping later assessments.
+// The targetData is the data that the assessment will be run against. The userApplicability is a slice
+// of strings that determine when the assessment is applicable.
 func (c *ControlEvaluation) Evaluate(targetData interface{}, userApplicability []string) {
 	if len(c.AssessmentLogs) == 0 {
 		c.Result = NeedsReview
@@ -34,9 +36,6 @@ func (c *ControlEvaluation) Evaluate(targetData interface{}, userApplicability [
 			result := assessment.Run(targetData)
 			c.Result = UpdateAggregateResult(c.Result, result)
 			c.Message = assessment.Message
-			if c.Result == Failed {
-				break
-			}
 		}
 	}
 }

--- a/control_evaluation_test.go
+++ b/control_evaluation_test.go
@@ -158,6 +158,52 @@ func TestEvaluate_EvaluatesAllSubRequirementsAfterFailure(t *testing.T) {
 	}
 }
 
+// TestEvaluate_RetainsFirstMessageForTiedAggregateResult documents that when two
+// sibling assessments share the winning precedence, the control-level message is
+// a stable summary that keeps the first tied assessment's message. Each assessment
+// still retains its own message in AssessmentLogs so consumers can report every
+// condition. The rule holds for every precedence level that can tie, not just Failed.
+func TestEvaluate_RetainsFirstMessageForTiedAggregateResult(t *testing.T) {
+	tests := []struct {
+		name            string
+		tiedResult      Result
+		expectAggregate Result
+	}{
+		{name: "Failed", tiedResult: Failed, expectAggregate: Failed},
+		{name: "NeedsReview", tiedResult: NeedsReview, expectAggregate: NeedsReview},
+		{name: "Unknown", tiedResult: Unknown, expectAggregate: Unknown},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			first := failingAssessmentPtr()
+			first.Steps = []AssessmentStep{func(interface{}) (Result, string, ConfidenceLevel) {
+				return test.tiedResult, "first context", Low
+			}}
+			second := failingAssessmentPtr()
+			second.Steps = []AssessmentStep{func(interface{}) (Result, string, ConfidenceLevel) {
+				return test.tiedResult, "second context", High
+			}}
+			c := &ControlEvaluation{AssessmentLogs: []*AssessmentLog{first, second}}
+
+			c.Evaluate(nil, testingApplicability)
+
+			if c.Result != test.expectAggregate {
+				t.Errorf("expected the control to aggregate to %v, got %v", test.expectAggregate, c.Result)
+			}
+			if c.Message != "first context" {
+				t.Errorf("expected the control to retain the first tied message, got %q", c.Message)
+			}
+			if first.Message != "first context" {
+				t.Errorf("expected the first assessment to retain its message, got %q", first.Message)
+			}
+			if second.Message != "second context" {
+				t.Errorf("expected the second assessment to retain its message, got %q", second.Message)
+			}
+		})
+	}
+}
+
 func TestAddAssesment(t *testing.T) {
 
 	controlEvaluationTestData[0].control.AddAssessment("test", "test", []string{}, []AssessmentStep{})

--- a/control_evaluation_test.go
+++ b/control_evaluation_test.go
@@ -112,6 +112,30 @@ func TestEvaluate(t *testing.T) {
 	}
 }
 
+// TestEvaluate_EvaluatesAllSubRequirementsAfterFailure is a regression test for a
+// bug where a failing sub-requirement caused Evaluate to break out of the loop,
+// leaving later sub-requirements of the same control unevaluated (reported as
+// NotRun with StepsExecuted=0). Each sub-requirement is independent and must be
+// evaluated regardless of a sibling's result, while the control still aggregates
+// to Failed.
+func TestEvaluate_EvaluatesAllSubRequirementsAfterFailure(t *testing.T) {
+	first := failingAssessmentPtr()
+	second := passingAssessmentPtr()
+	c := &ControlEvaluation{AssessmentLogs: []*AssessmentLog{first, second}}
+
+	c.Evaluate(nil, testingApplicability)
+
+	if second.StepsExecuted == 0 {
+		t.Errorf("expected the sub-requirement after a failing sibling to be evaluated, but it was skipped (StepsExecuted=0)")
+	}
+	if second.Result != Passed {
+		t.Errorf("expected the later sub-requirement to record its own result Passed, got %v", second.Result)
+	}
+	if c.Result != Failed {
+		t.Errorf("expected the control to still aggregate to Failed, got %v", c.Result)
+	}
+}
+
 func TestAddAssesment(t *testing.T) {
 
 	controlEvaluationTestData[0].control.AddAssessment("test", "test", []string{}, []AssessmentStep{})

--- a/control_evaluation_test.go
+++ b/control_evaluation_test.go
@@ -119,20 +119,42 @@ func TestEvaluate(t *testing.T) {
 // evaluated regardless of a sibling's result, while the control still aggregates
 // to Failed.
 func TestEvaluate_EvaluatesAllSubRequirementsAfterFailure(t *testing.T) {
-	first := failingAssessmentPtr()
-	second := passingAssessmentPtr()
-	c := &ControlEvaluation{AssessmentLogs: []*AssessmentLog{first, second}}
-
-	c.Evaluate(nil, testingApplicability)
-
-	if second.StepsExecuted == 0 {
-		t.Errorf("expected the sub-requirement after a failing sibling to be evaluated, but it was skipped (StepsExecuted=0)")
+	tests := []struct {
+		name        string
+		laterResult Result
+	}{
+		{name: "Passed", laterResult: Passed},
+		{name: "NeedsReview", laterResult: NeedsReview},
+		{name: "Unknown", laterResult: Unknown},
 	}
-	if second.Result != Passed {
-		t.Errorf("expected the later sub-requirement to record its own result Passed, got %v", second.Result)
-	}
-	if c.Result != Failed {
-		t.Errorf("expected the control to still aggregate to Failed, got %v", c.Result)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			first := failingAssessmentPtr()
+			first.Steps = []AssessmentStep{func(interface{}) (Result, string, ConfidenceLevel) {
+				return Failed, "failure context", Low
+			}}
+			second := passingAssessmentPtr()
+			second.Steps = []AssessmentStep{func(interface{}) (Result, string, ConfidenceLevel) {
+				return test.laterResult, "later context", High
+			}}
+			c := &ControlEvaluation{AssessmentLogs: []*AssessmentLog{first, second}}
+
+			c.Evaluate(nil, testingApplicability)
+
+			if second.StepsExecuted == 0 {
+				t.Errorf("expected the sub-requirement after a failing sibling to be evaluated, but it was skipped (StepsExecuted=0)")
+			}
+			if second.Result != test.laterResult {
+				t.Errorf("expected the later sub-requirement to record its own result %v, got %v", test.laterResult, second.Result)
+			}
+			if c.Result != Failed {
+				t.Errorf("expected the control to still aggregate to Failed, got %v", c.Result)
+			}
+			if c.Message != "failure context" {
+				t.Errorf("expected the control to retain the failing sub-requirement's message, got %q", c.Message)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- continue evaluating applicable sibling assessments after one assessment fails
- preserve the aggregate control result and the message associated with its highest-precedence result
- add regression coverage for later `Passed`, `NeedsReview`, and `Unknown` assessments

## Behavior change

Previously, the first failed assessment stopped evaluation of all remaining sibling assessments for the control. Those siblings stayed `NotRun`, with no executed steps or collected evaluation output.

After this change, every remaining applicable sibling assessment is invoked. Those assessments can now record results, messages, evidence, timestamps, and non-zero `StepsExecuted` values. Assessment steps supplied by external consumers may also perform side effects that previously did not occur after an earlier sibling failed.

Each individual assessment retains its existing step-level fail-fast behavior: if a step returns `Failed`, later steps within that same assessment are still skipped. The change removes only the control-level short-circuit between sibling assessments.

The control aggregate still preserves the highest-precedence result. A later lower-precedence sibling cannot replace the message associated with an earlier `Failed` result.

On a tie (two siblings sharing the winning precedence), the control `Message` deliberately keeps the first tied assessment's message as a stable summary, while every condition remains individually available in `AssessmentLogs`.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- coverage: 80.8% (71% required)
- configured command binaries build successfully
