### PR TITLE
Fix: update baseline scanner catalog name to osps-baseline-2026-02

### DIFF
--- a/.github/workflows/baseline-scanner.yml
+++ b/.github/workflows/baseline-scanner.yml
@@ -25,7 +25,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           token: ${{ secrets.GH_AUTH_TOKEN }}
-          catalog: "osps-baseline"
+          catalog: "osps-baseline-2026-02"
           upload-sarif: "true"
 
       - name: Upload Assessment Results


### PR DESCRIPTION
## Summary

Upstream breaking changes in the OSPS Baseline Action require the catalog name to be `osps-baseline-2026-02` instead of `osps-baseline`.

## Change

Updated the `catalog` input parameter in `.github/workflows/baseline-scanner.yml` from `osps-baseline` to `osps-baseline-2026-02`.

## Related

Closes #114

---

*This contribution was authored by an autonomous agent (RawNuke).*