### PR TITLE
ci: replace GH_AUTH_TOKEN PAT with Octo STS federation in baseline scanner

### DIFF
--- a/.github/chainguard/baseline-scanner.sts.yaml
+++ b/.github/chainguard/baseline-scanner.sts.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/octo-sts/app/refs/heads/main/pkg/octosts/octosts.TrustPolicy.json
+#
+# Octo STS trust policy for the OSPS Baseline Scanner workflow.
+# Allows GitHub Actions runs on the main branch of this repository to
+# federate for a short-lived GitHub App token, replacing the long-lived
+# GH_AUTH_TOKEN PAT. See .github/workflows/baseline-scanner.yml.
+
+issuer: https://token.actions.githubusercontent.com
+subject: repo:gemaraproj/go-gemara:ref:refs/heads/main
+
+permissions:
+  metadata: read # Repository and organization metadata, branch rules
+  contents: read # Repo contents, languages, releases, security policy
+  administration: read # Branch protection rule via GraphQL
+  checks: read # Check suites/runs on the latest commit
+  statuses: read # Classic commit status API

--- a/.github/workflows/baseline-scanner.yml
+++ b/.github/workflows/baseline-scanner.yml
@@ -6,25 +6,40 @@ on:
     - cron: "0 9 * * 1"
   workflow_dispatch: # Allow manual triggering
 
+permissions: {}
+
 jobs:
   osps-assessment:
     runs-on: ubuntu-latest
     name: Baseline Scan
 
     permissions:
-      contents: read
+      contents: read # Clone the repository
+      id-token: write # Federate with Octo STS for a short-lived GitHub App token
       security-events: write # Required for SARIF upload
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Exchanges this workflow's OIDC identity for a short-lived GitHub App
+      # token, per the trust policy in .github/chainguard/baseline-scanner.sts.yaml.
+      # Replaces the expiring GH_AUTH_TOKEN PAT.
+      - name: Federate with Octo STS
+        id: octo-sts
+        uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        with:
+          scope: ${{ github.repository }}
+          identity: baseline-scanner
 
       - name: Run Baseline Action
         uses: revanite-io/osps-baseline-action@b7d860b68755627c30ab692473511c90daee3ae8 # v1.3.4
         with:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
-          token: ${{ secrets.GH_AUTH_TOKEN }}
+          token: ${{ steps.octo-sts.outputs.token }}
           catalog: "osps-baseline-2026-02"
           upload-sarif: "true"
 


### PR DESCRIPTION
## What/Why

The PAT (Personal Access Token) behind `GH_AUTH_TOKEN` expired in early June 2026, and every baseline scan since (10 runs, example: run 31202047147) has failed with `401 Bad credentials`. This swaps the PAT for [Octo STS](https://github.com/octo-sts/app) federation: the workflow exchanges its OIDC identity for a short-lived GitHub App token minted against a trust policy checked into this repo, so there is no long-lived secret left to expire, rotate, or leak.

Drafted as a concrete example for the Octo STS discussion among maintainers.

## Proof it works

Structural verification only: actionlint passes and the trust policy validates against the Octo STS TrustPolicy schema. An end-to-end `workflow_dispatch` run is blocked until the [Octo STS App](https://github.com/apps/octo-sts) is installed on the `gemaraproj` org with access to this repo, which needs org admin. Once installed, a manual dispatch of this workflow is the real test.

## Risk + AI role

Low. Scheduled scan workflow and a new trust policy file only; no runtime code. The scan is already fully broken, so the downside is bounded. Changes were AI-generated and reviewed by @jmeridth.

## Review focus

- Trust policy permission set (`.github/chainguard/baseline-scanner.sts.yaml`): derived from the scanner's actual API calls (GraphQL branch protection needs `administration: read`; check runs and commit statuses need `checks`/`statuses`). May need adjusting after a live run.
- Whether the org wants repo-level trust policies like this one or a central org-level policy in the `gemaraproj/.github` repo instead.